### PR TITLE
Add backfill + rebuild workflows

### DIFF
--- a/.github/workflows/backfill-case-studies.yml
+++ b/.github/workflows/backfill-case-studies.yml
@@ -1,0 +1,52 @@
+name: Backfill Case Studies
+
+on:
+  workflow_dispatch:
+    inputs:
+      slugs:
+        description: 'Comma-separated Honeycomb slugs (verbatim, e.g. "Savory-Crust,Brothmonger-Brooklyn-Bone-Broth"). Optional.'
+        required: false
+        type: string
+      business_names:
+        description: 'Comma-separated business-name queries; case-insensitive substring match against seeded slugs. Optional.'
+        required: false
+        type: string
+      from_date:
+        description: 'Filter: campaignExpirationDate >= this YYYY-MM-DD. Optional.'
+        required: false
+        type: string
+      to_date:
+        description: 'Filter: campaignExpirationDate <= this YYYY-MM-DD. Optional.'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run backfill
+        env:
+          SLUGS: ${{ inputs.slugs }}
+          BUSINESS_NAMES: ${{ inputs.business_names }}
+          FROM_DATE: ${{ inputs.from_date }}
+          TO_DATE: ${{ inputs.to_date }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          WIX_API_KEY: ${{ secrets.WIX_API_KEY }}
+          WIX_SITE_ID: ${{ secrets.WIX_SITE_ID }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          NOTIFY_RECIPIENT: ${{ secrets.NOTIFY_RECIPIENT }}

--- a/.github/workflows/rebuild-case-study.yml
+++ b/.github/workflows/rebuild-case-study.yml
@@ -1,0 +1,37 @@
+name: Rebuild Case Study
+
+on:
+  workflow_dispatch:
+    inputs:
+      slugs:
+        description: 'Comma-separated case-study slugs to rebuild (use the Wix slug, e.g. "brothmonger-brooklyn-bone-broth")'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run rebuild
+        env:
+          SLUGS: ${{ inputs.slugs }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          WIX_API_KEY: ${{ secrets.WIX_API_KEY }}
+          WIX_SITE_ID: ${{ secrets.WIX_SITE_ID }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          NOTIFY_RECIPIENT: ${{ secrets.NOTIFY_RECIPIENT }}

--- a/README.md
+++ b/README.md
@@ -42,7 +42,22 @@ npm run check-campaigns        # runs tsc then executes dist/index.js
 
 ## Running on GitHub Actions
 
+### Daily cron
 Scheduled daily at 10 AM ET (`cron: '0 14 * * *'`). Manual trigger: Actions tab → "Daily Campaign Check" → Run workflow.
+
+### Backfill historical Funded campaigns
+Actions tab → "Backfill Case Studies" → Run workflow. Inputs (provide at least one):
+- `slugs` — comma-separated Honeycomb slugs (verbatim, e.g. `Savory-Crust,Brothmonger-Brooklyn-Bone-Broth`).
+- `business_names` — comma-separated queries; case-insensitive substring match against the seeded slug list.
+- `from_date` / `to_date` — `YYYY-MM-DD` close-date range; filters by `campaignExpirationDate`. Wide ranges scrape every seed slug to read the date, which is slow (5–10 min for the full 371-slug seed).
+
+Skips any candidate that already has a CMS entry (use Rebuild for those).
+
+### Rebuild an existing case study
+Actions tab → "Rebuild Case Study" → Run workflow. Input:
+- `slugs` — comma-separated **case-study slugs** (the Wix slug, lowercase-hyphenated; e.g. `brothmonger-brooklyn-bone-broth`), not the Honeycomb slug.
+
+Patches the existing CMS row in place (URL preserved), overwrites the hero image, resets `status` to `draft` so it goes back through review.
 
 ## Pre-flight before enabling cron
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "build": "tsc",
     "check-campaigns": "tsc && node dist/index.js",
+    "rebuild": "tsc && node dist/rebuild.js",
+    "backfill": "tsc && node dist/backfill.js",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit"
   },

--- a/src/backfill.ts
+++ b/src/backfill.ts
@@ -1,0 +1,200 @@
+import { CampaignFailure, RunReport } from './types';
+import { fetchCampaign } from './scraper';
+import { loadProcessed } from './tracker';
+import { processSlugCreate, classifyError } from './pipeline';
+import {
+  loadSmtpConfig,
+  sendPerCampaignEmail,
+  sendSummaryEmail,
+} from './notifier';
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`${name} required`);
+  return v;
+}
+
+function parseList(input: string | undefined): string[] {
+  if (!input) return [];
+  return input
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function isISODate(s: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(s);
+}
+
+async function resolveSlugsByName(
+  query: string,
+  seedSlugs: string[],
+): Promise<string[]> {
+  const lower = query.toLowerCase();
+  return seedSlugs.filter((slug) => slug.toLowerCase().includes(lower));
+}
+
+interface DateRange {
+  from?: string;
+  to?: string;
+}
+
+async function resolveSlugsByDateRange(
+  range: DateRange,
+  seedSlugs: string[],
+): Promise<{ matched: string[]; anomalies: string[] }> {
+  const matched: string[] = [];
+  const anomalies: string[] = [];
+  console.log(
+    `Date-range filter: scraping ${seedSlugs.length} seed slugs to read campaignExpirationDate (this is slow).`,
+  );
+  for (const slug of seedSlugs) {
+    try {
+      const payload = await fetchCampaign(slug);
+      const expiration = payload.campaignData.campaignExpirationDate;
+      if (!expiration || !isISODate(expiration.slice(0, 10))) {
+        anomalies.push(`${slug}: missing/invalid campaignExpirationDate`);
+        continue;
+      }
+      const exp = expiration.slice(0, 10);
+      if (range.from && exp < range.from) continue;
+      if (range.to && exp > range.to) continue;
+      matched.push(slug);
+    } catch (err) {
+      anomalies.push(`${slug}: scrape failed (${(err as Error).message})`);
+    }
+  }
+  return { matched, anomalies };
+}
+
+async function main(): Promise<number> {
+  const todayISO = new Date().toISOString();
+  const report: RunReport = {
+    runStartedISO: todayISO,
+    processed: [],
+    failures: [],
+    scrapeAnomalies: [],
+    trackedCount: 0,
+    rechecked: 0,
+    newlyTracked: 0,
+  };
+
+  const smtp = loadSmtpConfig();
+  let exitCode = 0;
+
+  try {
+    const slugInput = parseList(process.env.SLUGS);
+    const nameQueries = parseList(process.env.BUSINESS_NAMES);
+    const fromDate = process.env.FROM_DATE?.trim();
+    const toDate = process.env.TO_DATE?.trim();
+
+    const hasSlugs = slugInput.length > 0;
+    const hasNames = nameQueries.length > 0;
+    const hasDates = Boolean(fromDate || toDate);
+
+    if (!hasSlugs && !hasNames && !hasDates) {
+      throw new Error('At least one of SLUGS, BUSINESS_NAMES, or FROM_DATE/TO_DATE required');
+    }
+    if (fromDate && !isISODate(fromDate)) {
+      throw new Error(`FROM_DATE must be YYYY-MM-DD, got ${fromDate}`);
+    }
+    if (toDate && !isISODate(toDate)) {
+      throw new Error(`TO_DATE must be YYYY-MM-DD, got ${toDate}`);
+    }
+
+    const anthropicKey = requireEnv('ANTHROPIC_API_KEY');
+    const wixAuth = {
+      apiKey: requireEnv('WIX_API_KEY'),
+      siteId: requireEnv('WIX_SITE_ID'),
+    };
+    const deps = { anthropicKey, wixAuth, todayISO };
+
+    const processed = await loadProcessed();
+    const seedSlugs = processed.slugs;
+
+    const candidateSet = new Set<string>();
+
+    if (hasSlugs) {
+      for (const s of slugInput) candidateSet.add(s);
+      console.log(`Direct slugs: ${slugInput.length} added.`);
+    }
+
+    if (hasNames) {
+      for (const q of nameQueries) {
+        const matches = await resolveSlugsByName(q, seedSlugs);
+        console.log(`Business name "${q}" matched ${matches.length} slug(s):`, matches.join(', '));
+        for (const m of matches) candidateSet.add(m);
+      }
+    }
+
+    if (hasDates) {
+      const { matched, anomalies } = await resolveSlugsByDateRange(
+        { from: fromDate, to: toDate },
+        seedSlugs,
+      );
+      console.log(
+        `Date range ${fromDate ?? '*'}..${toDate ?? '*'} matched ${matched.length} slug(s).`,
+      );
+      report.scrapeAnomalies.push(...anomalies);
+      for (const m of matched) candidateSet.add(m);
+    }
+
+    const candidates = [...candidateSet].sort();
+    report.rechecked = candidates.length;
+    console.log(`Total candidates to backfill: ${candidates.length}`);
+
+    if (candidates.length === 0) {
+      console.warn('No candidates resolved. Nothing to do.');
+    }
+
+    for (const slug of candidates) {
+      try {
+        const outcome = await processSlugCreate(slug, deps);
+        if (!outcome.ok) {
+          report.failures.push({
+            slug,
+            stage: 'insert',
+            message: outcome.message,
+          });
+          console.warn(`SKIP ${slug}: ${outcome.message}`);
+          continue;
+        }
+        report.processed.push(outcome.report);
+        try {
+          await sendPerCampaignEmail(outcome.report, smtp, 'backfill');
+        } catch (err) {
+          report.failures.push({ slug, stage: 'notify', message: (err as Error).message });
+        }
+        console.log(`OK ${slug}: ${outcome.report.wixCmsUrl}`);
+      } catch (err) {
+        const f = classifyError(err);
+        report.failures.push({ slug, ...f } as CampaignFailure);
+        console.error(`FAIL ${slug}: ${f.message}`);
+      }
+    }
+  } catch (err) {
+    exitCode = 1;
+    report.failures.push({
+      slug: '(run)',
+      stage: 'unknown',
+      message: (err as Error).message ?? String(err),
+    });
+  } finally {
+    try {
+      await sendSummaryEmail(report, smtp);
+    } catch (err) {
+      console.error('summary email failed:', (err as Error).message);
+      exitCode = exitCode || 1;
+    }
+  }
+
+  return exitCode;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    console.error('fatal:', err);
+    process.exit(1);
+  },
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,8 @@
 import {
   RunReport,
-  CampaignReport,
   CampaignFailure,
 } from './types';
-import { fetchListing, fetchCampaign, ScrapeError } from './scraper';
+import { fetchListing, fetchCampaign } from './scraper';
 import {
   loadTracked,
   saveTracked,
@@ -14,47 +13,17 @@ import {
   candidatesForTransitionCheck,
   markProcessed,
 } from './tracker';
-import {
-  buildPromptInput,
-  generateCaseStudy,
-  GenerationError,
-} from './generator';
-import {
-  uploadHeroImage,
-  buildWixItem,
-  insertCaseStudy,
-  WixError,
-} from './wix';
+import { processSlugCreate, classifyError } from './pipeline';
 import {
   loadSmtpConfig,
   sendPerCampaignEmail,
   sendSummaryEmail,
 } from './notifier';
 
-const PUBLIC_BASE = 'https://honeycombcredit.com/case-studies/';
-
 function requireEnv(name: string): string {
   const v = process.env[name];
   if (!v) throw new Error(`${name} required`);
   return v;
-}
-
-function wixCmsLink(siteId: string, itemId: string): string {
-  return `https://manage.wix.com/dashboard/${siteId}/database/data/CaseStudies/${itemId}`;
-}
-
-function failureFor(slug: string, err: unknown): CampaignFailure {
-  if (err instanceof ScrapeError) return { slug, stage: 'scrape', message: err.message };
-  if (err instanceof GenerationError) return { slug, stage: 'generate', message: err.message };
-  if (err instanceof WixError) {
-    const stage =
-      err.stage.startsWith('media') ? 'upload'
-      : err.stage.startsWith('data') ? 'insert'
-      : 'unknown';
-    return { slug, stage: stage as CampaignFailure['stage'], message: err.message };
-  }
-  const e = err as Error;
-  return { slug, stage: 'unknown', message: e.message ?? String(err) };
 }
 
 async function main(): Promise<number> {
@@ -78,6 +47,7 @@ async function main(): Promise<number> {
       apiKey: requireEnv('WIX_API_KEY'),
       siteId: requireEnv('WIX_SITE_ID'),
     };
+    const deps = { anthropicKey, wixAuth, todayISO };
 
     const tracked = await loadTracked();
     const processed = await loadProcessed();
@@ -106,58 +76,43 @@ async function main(): Promise<number> {
     report.rechecked = candidates.length;
 
     for (const slug of candidates) {
-      let payload;
+      let stage: string;
       try {
-        payload = await fetchCampaign(slug);
+        const payload = await fetchCampaign(slug);
+        stage = payload.campaignData.campaignStage;
+        updateStage(tracked, slug, stage, todayISO);
       } catch (err) {
-        report.failures.push(failureFor(slug, err));
+        const f = classifyError(err);
+        report.failures.push({ slug, ...f } as CampaignFailure);
         continue;
       }
-      const stage = payload.campaignData.campaignStage;
-      updateStage(tracked, slug, stage, todayISO);
       if (stage !== 'Funded') continue;
 
-      // Step 3-6: generate, upload, insert, notify.
+      // Funded: run the create pipeline.
       try {
-        const input = buildPromptInput(payload.campaignData, todayISO);
-        const generated = await generateCaseStudy(input, anthropicKey);
-
-        if (!payload.ogImageUrl) {
-          throw new WixError('campaign missing ogImageUrl', 'media-fetch');
+        const outcome = await processSlugCreate(slug, deps);
+        if (!outcome.ok) {
+          report.failures.push({
+            slug,
+            stage: 'insert',
+            message: outcome.message,
+          });
+          continue;
         }
-        const heroMediaUrl = await uploadHeroImage(payload.ogImageUrl, wixAuth);
-
-        const wixItem = buildWixItem(generated, payload.campaignData, todayISO, heroMediaUrl);
-        const result = await insertCaseStudy(wixItem, wixAuth);
-
-        const campaignReport: CampaignReport = {
-          slug,
-          businessName: wixItem.businessName,
-          industry: wixItem.industry,
-          niche: wixItem.niche,
-          amountRaisedFormatted: wixItem.amountRaisedFormatted,
-          investorCount: wixItem.investorCount,
-          wixItemId: result._id,
-          wixCmsUrl: wixCmsLink(wixAuth.siteId, result._id),
-          publicPreviewUrl: PUBLIC_BASE + wixItem.slug,
-          humanizationChecked: result.humanizationChecked,
-          humanizationIssues: result.humanizationIssues,
-        };
-        report.processed.push(campaignReport);
+        report.processed.push(outcome.report);
         markProcessed(processed, slug);
-
         try {
-          await sendPerCampaignEmail(campaignReport, smtp);
+          await sendPerCampaignEmail(outcome.report, smtp, 'create');
         } catch (err) {
           report.failures.push({ slug, stage: 'notify', message: (err as Error).message });
         }
       } catch (err) {
-        report.failures.push(failureFor(slug, err));
+        const f = classifyError(err);
+        report.failures.push({ slug, ...f } as CampaignFailure);
       }
     }
 
     report.trackedCount = Object.keys(tracked.campaigns).length;
-
     await saveTracked(tracked);
     await saveProcessed(processed);
   } catch (err) {

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -34,9 +34,24 @@ function buildTransport(cfg: SmtpConfig): Transporter {
   });
 }
 
+export type CampaignEmailMode = 'create' | 'rebuild' | 'backfill';
+
+const SUBJECT_PREFIX: Record<CampaignEmailMode, string> = {
+  create: 'New case study draft ready',
+  rebuild: 'Case study rebuilt',
+  backfill: 'Backfilled case study draft ready',
+};
+
+const BODY_INTRO: Record<CampaignEmailMode, string> = {
+  create: 'New case study draft ready for review.',
+  rebuild: 'Case study has been rebuilt. Review and re-publish.',
+  backfill: 'Backfilled case study draft ready for review.',
+};
+
 export async function sendPerCampaignEmail(
   report: CampaignReport,
   cfg: SmtpConfig,
+  mode: CampaignEmailMode = 'create',
 ): Promise<void> {
   const status = report.humanizationChecked
     ? 'PASSED humanization validator.'
@@ -46,7 +61,7 @@ export async function sendPerCampaignEmail(
     : '';
 
   const body = [
-    `New case study draft ready for review.`,
+    BODY_INTRO[mode],
     ``,
     `Business: ${report.businessName}`,
     `Industry: ${report.industry}`,
@@ -65,7 +80,7 @@ export async function sendPerCampaignEmail(
   await buildTransport(cfg).sendMail({
     from: cfg.user,
     to: cfg.recipient,
-    subject: `New case study draft ready: ${report.businessName}`,
+    subject: `${SUBJECT_PREFIX[mode]}: ${report.businessName}`,
     text: body,
   });
 }

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,0 +1,149 @@
+import {
+  CampaignReport,
+  HoneycombCampaignPayload,
+  WixCaseStudyItem,
+} from './types';
+import { fetchCampaign, ScrapeError } from './scraper';
+import { buildPromptInput, generateCaseStudy, GenerationError } from './generator';
+import {
+  uploadHeroImage,
+  buildWixItem,
+  insertCaseStudy,
+  findItemBySlug,
+  updateCaseStudy,
+  WixError,
+} from './wix';
+
+const PUBLIC_BASE = 'https://honeycombcredit.com/case-studies/';
+
+export type PipelineMode = 'create' | 'rebuild';
+
+export interface PipelineDeps {
+  anthropicKey: string;
+  wixAuth: { apiKey: string; siteId: string };
+  todayISO: string;
+}
+
+export interface PipelineSuccess {
+  ok: true;
+  report: CampaignReport;
+  mode: PipelineMode;
+}
+
+export interface PipelineSkip {
+  ok: false;
+  reason: 'already-exists' | 'not-found' | 'no-hero-image' | 'no-payload';
+  message: string;
+}
+
+export type PipelineOutcome = PipelineSuccess | PipelineSkip;
+
+function wixCmsLink(siteId: string, itemId: string): string {
+  return `https://manage.wix.com/dashboard/${siteId}/database/data/CaseStudies/${itemId}`;
+}
+
+function buildCampaignReport(
+  slug: string,
+  wixItem: WixCaseStudyItem,
+  result: { _id: string; humanizationChecked: boolean; humanizationIssues: string | null },
+  siteId: string,
+): CampaignReport {
+  return {
+    slug,
+    businessName: wixItem.businessName,
+    industry: wixItem.industry,
+    niche: wixItem.niche,
+    amountRaisedFormatted: wixItem.amountRaisedFormatted,
+    investorCount: wixItem.investorCount,
+    wixItemId: result._id,
+    wixCmsUrl: wixCmsLink(siteId, result._id),
+    publicPreviewUrl: PUBLIC_BASE + wixItem.slug,
+    humanizationChecked: result.humanizationChecked,
+    humanizationIssues: result.humanizationIssues,
+  };
+}
+
+async function fetchAndGenerate(
+  slug: string,
+  deps: PipelineDeps,
+): Promise<{
+  payload: HoneycombCampaignPayload;
+  wixItem: WixCaseStudyItem;
+} | PipelineSkip> {
+  const payload = await fetchCampaign(slug);
+  if (!payload || !payload.campaignData) {
+    return { ok: false, reason: 'no-payload', message: `${slug}: campaign payload empty` };
+  }
+  if (!payload.ogImageUrl) {
+    return { ok: false, reason: 'no-hero-image', message: `${slug}: ogImageUrl missing` };
+  }
+
+  const input = buildPromptInput(payload.campaignData, deps.todayISO);
+  const generated = await generateCaseStudy(input, deps.anthropicKey);
+  const heroMediaUrl = await uploadHeroImage(payload.ogImageUrl, deps.wixAuth);
+  const wixItem = buildWixItem(generated, payload.campaignData, deps.todayISO, heroMediaUrl);
+  return { payload, wixItem };
+}
+
+export async function processSlugCreate(
+  slug: string,
+  deps: PipelineDeps,
+): Promise<PipelineOutcome> {
+  const existing = await findItemBySlug(slug, deps.wixAuth);
+  if (existing) {
+    return {
+      ok: false,
+      reason: 'already-exists',
+      message: `${slug}: CMS item already exists (${existing}); use rebuild`,
+    };
+  }
+  const built = await fetchAndGenerate(slug, deps);
+  if ('ok' in built && built.ok === false) return built;
+  const { wixItem } = built as { wixItem: WixCaseStudyItem };
+  const result = await insertCaseStudy(wixItem, deps.wixAuth);
+  return {
+    ok: true,
+    mode: 'create',
+    report: buildCampaignReport(slug, wixItem, result, deps.wixAuth.siteId),
+  };
+}
+
+export async function processSlugRebuild(
+  slug: string,
+  deps: PipelineDeps,
+): Promise<PipelineOutcome> {
+  const existingId = await findItemBySlug(slug, deps.wixAuth);
+  if (!existingId) {
+    return {
+      ok: false,
+      reason: 'not-found',
+      message: `${slug}: no existing CMS item to rebuild`,
+    };
+  }
+  const built = await fetchAndGenerate(slug, deps);
+  if ('ok' in built && built.ok === false) return built;
+  const { wixItem } = built as { wixItem: WixCaseStudyItem };
+  const result = await updateCaseStudy(existingId, wixItem, deps.wixAuth);
+  return {
+    ok: true,
+    mode: 'rebuild',
+    report: buildCampaignReport(slug, wixItem, result, deps.wixAuth.siteId),
+  };
+}
+
+export function classifyError(err: unknown): {
+  stage: 'scrape' | 'generate' | 'upload' | 'insert' | 'unknown';
+  message: string;
+} {
+  if (err instanceof ScrapeError) return { stage: 'scrape', message: err.message };
+  if (err instanceof GenerationError) return { stage: 'generate', message: err.message };
+  if (err instanceof WixError) {
+    const stage =
+      err.stage.startsWith('media') ? 'upload'
+      : err.stage.startsWith('data') ? 'insert'
+      : 'unknown';
+    return { stage: stage as 'upload' | 'insert' | 'unknown', message: err.message };
+  }
+  const e = err as Error;
+  return { stage: 'unknown', message: e.message ?? String(err) };
+}

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -1,0 +1,104 @@
+import { CampaignFailure, RunReport } from './types';
+import { processSlugRebuild, classifyError } from './pipeline';
+import {
+  loadSmtpConfig,
+  sendPerCampaignEmail,
+  sendSummaryEmail,
+} from './notifier';
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`${name} required`);
+  return v;
+}
+
+function parseSlugs(input: string | undefined): string[] {
+  if (!input) return [];
+  return input
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+async function main(): Promise<number> {
+  const todayISO = new Date().toISOString();
+  const report: RunReport = {
+    runStartedISO: todayISO,
+    processed: [],
+    failures: [],
+    scrapeAnomalies: [],
+    trackedCount: 0,
+    rechecked: 0,
+    newlyTracked: 0,
+  };
+
+  const smtp = loadSmtpConfig();
+  let exitCode = 0;
+
+  try {
+    const slugs = parseSlugs(process.env.SLUGS);
+    if (slugs.length === 0) {
+      throw new Error('SLUGS env var (comma-separated) required');
+    }
+
+    const anthropicKey = requireEnv('ANTHROPIC_API_KEY');
+    const wixAuth = {
+      apiKey: requireEnv('WIX_API_KEY'),
+      siteId: requireEnv('WIX_SITE_ID'),
+    };
+    const deps = { anthropicKey, wixAuth, todayISO };
+
+    report.rechecked = slugs.length;
+    console.log(`Rebuilding ${slugs.length} case study(s):`, slugs.join(', '));
+
+    for (const slug of slugs) {
+      try {
+        const outcome = await processSlugRebuild(slug, deps);
+        if (!outcome.ok) {
+          report.failures.push({
+            slug,
+            stage: 'insert',
+            message: outcome.message,
+          });
+          console.warn(`SKIP ${slug}: ${outcome.message}`);
+          continue;
+        }
+        report.processed.push(outcome.report);
+        try {
+          await sendPerCampaignEmail(outcome.report, smtp, 'rebuild');
+        } catch (err) {
+          report.failures.push({ slug, stage: 'notify', message: (err as Error).message });
+        }
+        console.log(`OK ${slug}: ${outcome.report.wixCmsUrl}`);
+      } catch (err) {
+        const f = classifyError(err);
+        report.failures.push({ slug, ...f } as CampaignFailure);
+        console.error(`FAIL ${slug}: ${f.message}`);
+      }
+    }
+  } catch (err) {
+    exitCode = 1;
+    report.failures.push({
+      slug: '(run)',
+      stage: 'unknown',
+      message: (err as Error).message ?? String(err),
+    });
+  } finally {
+    try {
+      await sendSummaryEmail(report, smtp);
+    } catch (err) {
+      console.error('summary email failed:', (err as Error).message);
+      exitCode = exitCode || 1;
+    }
+  }
+
+  return exitCode;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    console.error('fatal:', err);
+    process.exit(1);
+  },
+);

--- a/src/wix.ts
+++ b/src/wix.ts
@@ -215,3 +215,78 @@ export async function insertCaseStudy(
         : null,
   };
 }
+
+export async function findItemBySlug(
+  slug: string,
+  auth: WixAuth,
+): Promise<string | null> {
+  const res = await fetch('https://www.wixapis.com/wix-data/v2/items/query', {
+    method: 'POST',
+    headers: { ...authHeaders(auth), 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      dataCollectionId: COLLECTION_ID,
+      query: {
+        filter: { slug: { $eq: slug } },
+        paging: { limit: 1 },
+      },
+    }),
+  });
+  if (!res.ok) {
+    throw new WixError(
+      `query HTTP ${res.status}: ${await res.text()}`,
+      'data-query',
+    );
+  }
+  const json = (await res.json()) as {
+    dataItems?: Array<{ _id?: string; id?: string }>;
+  };
+  const first = json.dataItems?.[0];
+  return first ? first._id || first.id || null : null;
+}
+
+export async function updateCaseStudy(
+  itemId: string,
+  item: WixCaseStudyItem,
+  auth: WixAuth,
+): Promise<WixInsertResult> {
+  const updateRes = await fetch(
+    `https://www.wixapis.com/wix-data/v2/items/${encodeURIComponent(itemId)}`,
+    {
+      method: 'PUT',
+      headers: { ...authHeaders(auth), 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        dataCollectionId: COLLECTION_ID,
+        dataItem: { data: { ...item, _id: itemId } },
+      }),
+    },
+  );
+  if (!updateRes.ok) {
+    throw new WixError(
+      `update HTTP ${updateRes.status}: ${await updateRes.text()}`,
+      'data-update',
+    );
+  }
+
+  const getUrl = `https://www.wixapis.com/wix-data/v2/items/${encodeURIComponent(
+    itemId,
+  )}?dataCollectionId=${COLLECTION_ID}`;
+  const getRes = await fetch(getUrl, { headers: authHeaders(auth) });
+  if (!getRes.ok) {
+    throw new WixError(
+      `post-update fetch HTTP ${getRes.status}: ${await getRes.text()}`,
+      'data-fetch',
+    );
+  }
+  const getJson = (await getRes.json()) as {
+    dataItem?: { data?: Record<string, unknown> };
+  };
+  const data = getJson.dataItem?.data ?? {};
+  return {
+    _id: itemId,
+    humanizationChecked: Boolean(data.humanizationChecked),
+    humanizationIssues:
+      typeof data.humanizationIssues === 'string'
+        ? (data.humanizationIssues as string)
+        : null,
+  };
+}


### PR DESCRIPTION
## Summary

Two new operator-triggered workflows that complement the daily cron, plus a small refactor to share the per-slug pipeline.

**Backfill** — generate case studies for already-Funded historical campaigns (the 371 seeded in `data/processed_campaigns.json`). Three input modes, all optional but at least one required:
- `slugs` — comma-separated Honeycomb slugs verbatim
- `business_names` — comma-separated queries; case-insensitive substring match against seed
- `from_date` / `to_date` — close-date range (filters by `campaignExpirationDate`)

Skips candidates that already have a CMS entry (suggests Rebuild).

**Rebuild** — regenerate one or more case studies that already exist in the CMS. Same Wix item ID is preserved (URL stays stable), hero image is re-uploaded, `status` is reset to `draft` so the result goes back through review.

## Architectural changes

- New `src/pipeline.ts` extracts the per-slug `fetch → generate → upload → insert/update` flow, with `processSlugCreate` and `processSlugRebuild` variants. Daily cron (`index.ts`), backfill, and rebuild all reuse it.
- `src/wix.ts` gains `findItemBySlug` (Wix Data query by slug field) and `updateCaseStudy` (PUT to patch in place, then re-fetch for the `beforeUpdate` hook's verdict).
- `src/notifier.ts` per-campaign email accepts a `mode` parameter so the subject reads correctly: `New case study draft ready` / `Case study rebuilt` / `Backfilled case study draft ready`.

## Test plan

Both workflows are `workflow_dispatch` only — no scheduled runs, no automatic triggers. Pre-merge sanity:

- [ ] `npm run typecheck` passes locally (✅ verified).

Post-merge smoke (do these once main has the new workflows):

- [ ] **Rebuild** a known item: pick any case-study slug currently in Wix CMS, run "Rebuild Case Study" with that slug. Expected: per-campaign email arrives with subject `Case study rebuilt: …`, CMS item shows fresh content + `status = "draft"`, item ID unchanged.
- [ ] **Backfill by slug**: pick one historical Funded slug from `data/processed_campaigns.json` that has no CMS entry yet (e.g. `Savory-Crust`), run "Backfill Case Studies" with `slugs=Savory-Crust`. Expected: per-campaign email with subject `Backfilled case study draft ready: …`, new CMS item with all ~30 fields populated.
- [ ] **Backfill by name**: run "Backfill Case Studies" with `business_names=rebundle`. Expected: matches both `Rebundle` and `Rebundle-2`, summary email lists both.
- [ ] **Backfill by date range**: run with `from_date=2024-01-01, to_date=2024-06-30` against the seed. Expected: scrape phase logs ~371 fetches, then processes only campaigns whose `campaignExpirationDate` falls in range. Slow (5–10 min); fine for manual.
- [ ] **Backfill collision**: re-run a backfill against a slug that just got published. Expected: skipped with message "CMS item already exists; use rebuild".

## Notes

- Backfill does **not** add to `processed_campaigns.json` — those slugs are already there as part of the seed; processed-state is unaffected.
- Rebuild does **not** touch `processed_campaigns.json` either; it operates entirely on the CMS layer.
- Hero image is re-uploaded on rebuild (one fresh Wix Media file per rebuild). If storage growth becomes a concern over many rebuilds, a future change could query the existing item's `heroImage` URL and reuse it instead.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JJn3VvZsLqkDMHBTZVspYv)_