### PR TITLE
Omit canonicalOverride when empty (fix Wix URL validation warning)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -160,7 +160,7 @@ export interface WixCaseStudyItem {
   ogTitle: string;
   ogDescription: string;
   ogImage: string;
-  canonicalOverride: string;
+  canonicalOverride?: string;
   ctaText: string;
   ctaUrl: string;
   campaignUrl: string;

--- a/src/wix.ts
+++ b/src/wix.ts
@@ -153,7 +153,9 @@ export function buildWixItem(
     ogTitle: generated.ogTitle,
     ogDescription: generated.ogDescription,
     ogImage: heroMediaUrl,
-    canonicalOverride: '',
+    // canonicalOverride intentionally omitted — Wix URL field rejects empty
+    // strings. Reviewer can populate it manually in CMS if a canonical
+    // override is ever needed.
     ctaText: generated.ctaText,
     ctaUrl: STATIC_CTA_URL,
     campaignUrl: CAMPAIGN_URL_BASE + (campaign.slug ?? ''),


### PR DESCRIPTION
## Summary

Fixes a Wix CMS validation warning that surfaces on every new case-study row: `canonicalOverride` was being sent as `""`, but the underlying CMS column is typed as URL, which rejects empty strings.

## What changes

- `src/types.ts` — `canonicalOverride` is now optional on `WixCaseStudyItem`.
- `src/wix.ts` — `buildWixItem` no longer sets the key when there is no override. Wix sees no field at all and skips URL validation.

## Caught how

User reported on the first successful backfill (Vermillion-Farms): the row inserted clean, but the `canonicalOverride` field in the Wix CMS UI showed "This value doesn't match the URL field type" and was blank. Spec § 5.3 documents the field as empty at insert, so the fix is to actually leave it absent on insert rather than send an empty string.

## Test plan

- [ ] `npm run typecheck` passes (✅ verified locally).
- [ ] After merge, run **Backfill Case Studies** on a fresh slug (e.g. another historical Funded campaign you haven't backfilled yet). Confirm the resulting Wix row shows no validation warning on `canonicalOverride`.
- [ ] For the existing Vermillion-Farms row: either save the field empty in the Wix CMS UI to clear the warning, or run **Rebuild Case Study** on its slug — rebuild calls the same `buildWixItem` path, so it'll patch the row without the empty-string value.

## Notes

- No retroactive sweep — only the one already-published Vermillion-Farms row is affected, and the warning is cosmetic (the field is intended to be blank). Easy to clear by hand or by rebuild.
- If a future use case wants to write an actual canonical URL override, set the field type can stay as-is and `canonicalOverride` becomes a real value passed through.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JJn3VvZsLqkDMHBTZVspYv)_