### PR TITLE
Scrub em-dashes from Claude output (replace with hyphens)

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -84,6 +84,20 @@ function stripFences(s: string): string {
     .trim();
 }
 
+// Replace em-dashes with hyphens. Claude habitually overuses em-dashes
+// despite the prompt's "0 or 1 per 500 words" rule and the Wix humanization
+// validator caps em-dash density. Hyphens read fine in narrative copy and
+// always pass the validator.
+function scrubEmDashes(parsed: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...parsed };
+  for (const key of Object.keys(out)) {
+    if (typeof out[key] === 'string') {
+      out[key] = (out[key] as string).replace(/—/g, '-');
+    }
+  }
+  return out;
+}
+
 function validateOutput(parsed: unknown, slug: string): GeneratedCaseStudy {
   if (!parsed || typeof parsed !== 'object') {
     throw new GenerationError('output is not an object', slug);
@@ -150,5 +164,9 @@ export async function generateCaseStudy(
       input.slug,
     );
   }
-  return validateOutput(parsed, input.slug);
+  if (!parsed || typeof parsed !== 'object') {
+    throw new GenerationError('output is not an object', input.slug);
+  }
+  const scrubbed = scrubEmDashes(parsed as Record<string, unknown>);
+  return validateOutput(scrubbed, input.slug);
 }


### PR DESCRIPTION
## Summary

Replace em-dashes (`—`) with hyphens (`-`) in every string field of the Claude output before sending to Wix. Fixes the recurring humanization failure mode where the validator's em-dash density cap trips on otherwise-clean drafts.

## Why

Claude leans heavily on em-dashes as a stylistic crutch despite:
- The runtime prompt's explicit "0 or 1 per 500 words" rule
- Self-check item #12 ("Count em-dashes in story. Should be 0 or 1.")
- The brand voice guidance preferring commas / periods

Real-world: the Vermillion-Farms backfill produced 8 em-dashes (density 4.9/500), tripping `[em_dash_overuse]` and forcing a manual rescue. This will keep happening until we deterministically scrub at the agent layer.

## Implementation

`src/generator.ts`:
- New `scrubEmDashes(parsed)` helper does a flat string replace `/—/g → '-'` across every top-level string field of the parsed JSON.
- Applied after JSON parse, before validation. Length-sensitive checks (`metaTitle` 50–60, `metaDescription` 140–160, `systemSchemaJson` < 8000) are unaffected because em-dash and hyphen are both single Unicode code units.
- `systemSchemaJson` is also scrubbed — em-dashes inside JSON-LD descriptions look just as AI-generated to a reviewer, and string replace is safe because em-dash doesn't need JSON escaping.

## Test plan

- [x] `npm run typecheck` passes locally.
- [ ] After merge, **Rebuild Case Study** with slug `vermillion-farms-coupland-texas`. Expected: `Humanization: PASSED humanization validator.` in the per-campaign email. The story field on the patched row contains zero `—` characters.
- [ ] On the next backfill or daily-cron Funded transition, confirm the same — no em-dash failures should reach the validator.

## Notes

- Doesn't touch en-dashes (`–`), which the prompt explicitly endorses.
- Doesn't change anything about the prompt — it's a belt-and-suspenders fix at the deterministic post-process layer. The prompt instructions stay in place; this just ensures we never ship em-dashes regardless of what the model returns.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JJn3VvZsLqkDMHBTZVspYv)_