### PR TITLE
fix(ci): astro sync before tsc; bump checkout/setup-node to v5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,8 +22,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/detect.yml
+++ b/.github/workflows/detect.yml
@@ -22,11 +22,11 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/on-comment.yml
+++ b/.github/workflows/on-comment.yml
@@ -33,13 +33,13 @@ jobs:
             "https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
             -d '{"content":"eyes"}' >/dev/null
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/on-issue.yml
+++ b/.github/workflows/on-issue.yml
@@ -18,13 +18,13 @@ jobs:
       contains(github.event.issue.labels.*.name, 'form: redraft-feedback')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "astro sync && tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "detect": "tsx scripts/detect.ts",


### PR DESCRIPTION
Hotfix for the red Deploy #2 on PR #6's merge.

## What broke

`tsc --noEmit` failed in CI with two errors in `src/content/config.ts`:

```
src/content/config.ts:17  Cannot find module 'astro:content' or its corresponding type declarations.
src/content/config.ts:44  Parameter 'obj' implicitly has an 'any' type.
```

Local typecheck was clean, so this only surfaced once the gate I added in PR #6 actually ran in a fresh CI environment.

## Why

`astro:content` is a virtual module — its types live in `.astro/types.d.ts`, generated by Astro itself (during `astro sync` or `astro build`). The new typecheck step runs *before* the build step on a cold runner, so the type file doesn't exist yet. Locally, prior `npm run build` runs had populated `.astro/`, masking the issue.

Error #2 is a downstream cascade: with `defineCollection` unresolved, Zod's chained generics degrade to `any`, and the `.refine()` callback's `obj` parameter trips strict-mode's `noImplicitAny`.

## Fix

One line:

```diff
-"typecheck": "tsc --noEmit"
+"typecheck": "astro sync && tsc --noEmit"
```

`astro sync` only generates types — it doesn't bundle, transform, or build pages. Costs ~1.3s on a cold cache, no-ops on a warm one.

**Verified locally** by deleting `.astro/` and re-running `npm run typecheck` — clean.

## Bonus: action version bumps

Same PR also bumps `actions/checkout@v4 → v5` and `actions/setup-node@v4 → v5` across all four workflows. Both v5 releases are the Node 24-native versions that GitHub's deprecation notice (Node 20 EOL on runners September 2026) tells us to migrate to. Pure swap.

## Verification

- `rm -rf .astro && npm run typecheck` → clean
- `npm test` → 29/29 passing
- `npm run build` → 2 pages built
- All four `.yml` files still parse as valid YAML

## Post-merge

Deploy #3 should run green end-to-end (typecheck → test → build → deploy). After that, every push to `main` deploys cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_014jtP3vYDPkVZzTYPzLHMmq)_