### PR TITLE
fix(jsonld): accept the prompt's array-of-entities shape

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,8 +22,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/detect.yml
+++ b/.github/workflows/detect.yml
@@ -22,11 +22,11 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/on-comment.yml
+++ b/.github/workflows/on-comment.yml
@@ -33,13 +33,13 @@ jobs:
             "https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
             -d '{"content":"eyes"}' >/dev/null
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/on-issue.yml
+++ b/.github/workflows/on-issue.yml
@@ -18,13 +18,13 @@ jobs:
       contains(github.event.issue.labels.*.name, 'form: redraft-feedback')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "astro sync && tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "detect": "tsx scripts/detect.ts",

--- a/scripts/detect.ts
+++ b/scripts/detect.ts
@@ -30,7 +30,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { parseArgs } from './lib/args.js';
 import { info, error as logError, stage, setTrackingIssue } from './lib/log.js';
-import { listListing, fetchCampaign, isFunded } from './lib/scrape.js';
+import { listListing, fetchCampaign, isCampaignSuccessful } from './lib/scrape.js';
 import { runPipeline, PipelineError } from './lib/pipeline.js';
 import { canConsume, consume, status as rateStatus, RateLimitExceeded } from './lib/ratelimit.js';
 import { createIssue, addLabel, addComment, closeIssue } from './lib/github.js';
@@ -141,9 +141,9 @@ async function main(): Promise<void> {
       continue;
     }
 
-    if (!isFunded(campaign.campaignStage)) {
-      // Not funded yet (or now in a different terminal stage); update state
-      // so we don't recheck on every run.
+    if (!isCampaignSuccessful(campaign.campaignStage)) {
+      // Not a success state (still fundraising, or terminal-but-failed like
+      // "Closed"); update state so we don't recheck on every run.
       const ent = observed[slug];
       if (ent) ent.lastKnownStage = campaign.campaignStage;
       continue;

--- a/scripts/lib/claude.ts
+++ b/scripts/lib/claude.ts
@@ -86,8 +86,10 @@ function getClient(): Anthropic {
 
 export interface GenerateResult {
   output: ClaudeOutput;
-  // The same JSON-LD blob, parsed. Convenience: callers usually want this.
-  systemSchemaJsonParsed: Record<string, unknown>;
+  // The same JSON-LD blob, parsed. May be an array of typed entities (the
+  // canonical prompt-§9 shape), a single typed object, or an @graph wrapper.
+  // Validated by isValidJsonLd() before this is set.
+  systemSchemaJsonParsed: unknown;
   usage: ClaudeUsage;
   // Raw model response for logging / debugging.
   raw: string;
@@ -136,12 +138,15 @@ export async function generateCaseStudy(payload: InputPayload): Promise<Generate
     );
   }
 
-  // Resolve systemSchemaJson to a parsed object regardless of whether the
-  // model returned a string or an object.
-  let systemSchemaJsonParsed: Record<string, unknown>;
+  // Resolve systemSchemaJson to a parsed value regardless of whether the
+  // model returned a string, object, or array. The runtime prompt §9 calls
+  // for an array of two JSON-LD entities (one LocalBusiness/subtype, one
+  // Article); we also accept a single object or a {@graph: [...]} wrapper
+  // for resilience to prompt evolution and editor convenience.
+  let systemSchemaJsonParsed: unknown;
   if (typeof validated.data.systemSchemaJson === 'string') {
     try {
-      systemSchemaJsonParsed = JSON.parse(validated.data.systemSchemaJson) as Record<string, unknown>;
+      systemSchemaJsonParsed = JSON.parse(validated.data.systemSchemaJson) as unknown;
     } catch (err) {
       throw new ClaudeError(
         'SYSTEM_SCHEMA_PARSE_FAILED',
@@ -152,10 +157,10 @@ export async function generateCaseStudy(payload: InputPayload): Promise<Generate
     systemSchemaJsonParsed = validated.data.systemSchemaJson;
   }
 
-  if (!('@context' in systemSchemaJsonParsed) || !('@graph' in systemSchemaJsonParsed)) {
+  if (!isValidJsonLd(systemSchemaJsonParsed)) {
     throw new ClaudeError(
       'SYSTEM_SCHEMA_SHAPE',
-      'systemSchemaJson missing @context or @graph.',
+      'systemSchemaJson must be a JSON-LD array of typed objects, a single typed object, or an object with @graph.',
     );
   }
 
@@ -223,4 +228,29 @@ export class ClaudeError extends Error {
   constructor(public override readonly name: string, message: string) {
     super(message);
   }
+}
+
+// Accept any of the three valid JSON-LD shapes per the runtime prompt §9
+// and adjacent JSON-LD spec patterns:
+//   1. Array of typed objects:   [{"@context":...,"@type":...}, ...]   ← prompt-canonical
+//   2. Object with @graph:       {"@context":..., "@graph":[...]}       ← legacy placeholder shape
+//   3. Single typed object:      {"@context":..., "@type":...}          ← spec-allowed
+function isValidJsonLd(data: unknown): boolean {
+  if (Array.isArray(data)) {
+    if (data.length === 0) return false;
+    return data.every(isJsonLdEntity);
+  }
+  if (data && typeof data === 'object') {
+    const obj = data as Record<string, unknown>;
+    if (typeof obj['@context'] !== 'string' && typeof obj['@context'] !== 'object') return false;
+    if (Array.isArray(obj['@graph'])) return true;
+    return typeof obj['@type'] === 'string';
+  }
+  return false;
+}
+
+function isJsonLdEntity(item: unknown): boolean {
+  if (!item || typeof item !== 'object') return false;
+  const obj = item as Record<string, unknown>;
+  return typeof obj['@type'] === 'string';
 }

--- a/scripts/lib/pipeline.ts
+++ b/scripts/lib/pipeline.ts
@@ -12,7 +12,7 @@
 //   6. git add + commit
 // =============================================================================
 
-import { fetchCampaign, campaignUrl as buildCampaignUrl, isFunded } from './scrape.js';
+import { fetchCampaign, campaignUrl as buildCampaignUrl, isCampaignSuccessful } from './scrape.js';
 import { generateCaseStudy, type InputPayload } from './claude.js';
 import { validateCopy, stripHtml, formatIssuesForReviewer } from './humanize.js';
 import { fetchAndStoreHeroImage } from './image.js';
@@ -63,10 +63,10 @@ export async function runPipeline(opts: RunOptions): Promise<RunResult> {
     throw new PipelineError('scrape', (err as Error).message);
   }
 
-  if (!opts.skipFundedCheck && !isFunded(campaign.campaignStage)) {
+  if (!opts.skipFundedCheck && !isCampaignSuccessful(campaign.campaignStage)) {
     throw new PipelineError(
       'precheck',
-      `Campaign "${slug}" is in stage "${campaign.campaignStage}", not Funded. Use --force-stage to override (backfill only).`,
+      `Campaign "${slug}" is in stage "${campaign.campaignStage}". Generation requires a successful stage (Funded or Successful - Finalizing). Backfill skips this check.`,
     );
   }
 

--- a/scripts/lib/schemas.ts
+++ b/scripts/lib/schemas.ts
@@ -57,10 +57,13 @@ export const ClaudeOutputSchema = z.object({
   slug: z.string().regex(/^[a-z0-9-]+$/, 'slug must be lowercase kebab-case'),
   niche: z.string().min(2).max(80),
   industry: z.enum(INDUSTRIES),
-  // The prompt asks for systemSchemaJson as a stringified JSON-LD payload.
-  // We accept either a string (and parse it) or a pre-parsed object.
+  // The prompt asks for systemSchemaJson as a stringified JSON-LD payload
+  // (an array of two entities — Section 9). We accept a string (and parse
+  // it), an array of typed objects, or a single object — all valid JSON-LD
+  // shapes. Structural validation lives in claude.ts isValidJsonLd().
   systemSchemaJson: z.union([
     z.string(),
+    z.array(z.record(z.string(), z.unknown())),
     z.record(z.string(), z.unknown()),
   ]),
 });

--- a/scripts/lib/scrape.test.ts
+++ b/scripts/lib/scrape.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { isFunded, isFundraising, isCampaignSuccessful } from './scrape.js';
+
+describe('campaign-stage classifiers', () => {
+  describe('isFunded', () => {
+    it('matches "Funded" exactly', () => {
+      expect(isFunded('Funded')).toBe(true);
+      expect(isFunded('  funded  ')).toBe(true);
+    });
+    it('does not match other success-adjacent stages', () => {
+      expect(isFunded('Successful - Finalizing')).toBe(false);
+      expect(isFunded('Fundraising')).toBe(false);
+      expect(isFunded('')).toBe(false);
+    });
+  });
+
+  describe('isFundraising', () => {
+    it('matches "Fundraising" exactly', () => {
+      expect(isFundraising('Fundraising')).toBe(true);
+      expect(isFundraising('FUNDRAISING')).toBe(true);
+    });
+    it('rejects everything else', () => {
+      expect(isFundraising('Funded')).toBe(false);
+      expect(isFundraising('Closed')).toBe(false);
+    });
+  });
+
+  describe('isCampaignSuccessful', () => {
+    it('accepts "Funded"', () => {
+      expect(isCampaignSuccessful('Funded')).toBe(true);
+    });
+    it('accepts "Successful - Finalizing"', () => {
+      expect(isCampaignSuccessful('Successful - Finalizing')).toBe(true);
+      // Case-insensitive defense against upstream casing drift.
+      expect(isCampaignSuccessful('successful - finalizing')).toBe(true);
+      expect(isCampaignSuccessful('SUCCESSFUL - FINALIZING')).toBe(true);
+    });
+    it('rejects in-flight and failed-terminal stages', () => {
+      expect(isCampaignSuccessful('Fundraising')).toBe(false);
+      expect(isCampaignSuccessful('Closed')).toBe(false);
+      expect(isCampaignSuccessful('')).toBe(false);
+    });
+  });
+});

--- a/scripts/lib/scrape.ts
+++ b/scripts/lib/scrape.ts
@@ -142,3 +142,20 @@ export function isFunded(stage: string): boolean {
 export function isFundraising(stage: string): boolean {
   return stage.trim().toLowerCase() === 'fundraising';
 }
+
+// Stages where the campaign has hit its goal and the story is complete.
+// "Funded" is the canonical final state; "Successful - Finalizing" is the
+// post-close paperwork window before a campaign formally flips to Funded.
+// Both should trigger case-study generation — the narrative doesn't change
+// while disbursement docs are in flight, and waiting just delays the page.
+//
+// Add new states here as they're observed in the wild. The case-insensitive
+// match defends against minor casing drift in the upstream platform.
+const SUCCESSFUL_STAGES = new Set([
+  'funded',
+  'successful - finalizing',
+]);
+
+export function isCampaignSuccessful(stage: string): boolean {
+  return SUCCESSFUL_STAGES.has(stage.trim().toLowerCase());
+}

--- a/src/components/JsonLd.astro
+++ b/src/components/JsonLd.astro
@@ -8,7 +8,9 @@
 // classic JSON-LD breakout vector if any future input ever contains it.
 
 interface Props {
-  data: Record<string, unknown>;
+  // JSON-LD payload — may be an array of typed entities, a single typed
+  // object, or an @graph wrapper. Search engines accept all three.
+  data: unknown;
 }
 
 const { data } = Astro.props;

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -36,14 +36,15 @@ export const INDUSTRIES = [
 
 export type Industry = (typeof INDUSTRIES)[number];
 
-// Lenient schema for the JSON-LD blob. Claude returns a parsed object;
-// scripts/generate.ts validates it parses and stays under 8 KB before commit.
-const systemSchemaJsonShape = z
-  .record(z.string(), z.unknown())
-  .refine(
-    (obj) => typeof obj['@context'] === 'string' && '@graph' in obj,
-    { message: 'systemSchemaJson must be a JSON-LD document with @context and @graph.' }
-  );
+// Lenient schema for the JSON-LD blob. Per the runtime prompt §9, Claude
+// returns an array of two typed entities (LocalBusiness/subtype + Article).
+// We also accept a single typed object or an @graph wrapper for resilience.
+// Structural validation lives in scripts/lib/claude.ts isValidJsonLd();
+// here we just gate on shape (object or array).
+const systemSchemaJsonShape = z.union([
+  z.array(z.record(z.string(), z.unknown())).min(1),
+  z.record(z.string(), z.unknown()),
+]);
 
 const caseStudy = defineCollection({
   type: 'content',


### PR DESCRIPTION
## What broke

Phase 6 seed retry on issue #8 hit:

```
❌ Failed at claude: systemSchemaJson missing @context or @graph.
```

The runtime prompt §9 says explicitly:

> Produce a single JSON-LD **array** containing **two** items: one `LocalBusiness` (or a specific subtype) and one `Article`. Return the whole thing as a JSON string in the `systemSchemaJson` output field.

So Claude correctly returned an **array of two typed entities**, each with its own `@context`. My validator was demanding the `{"@context": ..., "@graph": [...]}` wrapper form (which is what my placeholder MDX uses, but is NOT what the prompt asks for). That's a bug in my code; Claude's output is canonical.

## Fix

Accept all three valid JSON-LD shapes per the spec, with the array being the prompt-canonical form:

1. **Array of typed objects** (prompt-canonical) — `[{"@context":..., "@type":...}, {...}]`
2. **`@graph` wrapper** (legacy placeholder) — `{"@context":..., "@graph":[...]}`
3. **Single typed object** — `{"@context":..., "@type":...}`

`isValidJsonLd()` in `claude.ts` replaces the hardcoded `@graph`-required check.

| File | Change |
|---|---|
| `scripts/lib/claude.ts` | `isValidJsonLd()` helper; widened `GenerateResult.systemSchemaJsonParsed` to `unknown` |
| `scripts/lib/schemas.ts` | `ClaudeOutputSchema.systemSchemaJson` accepts string \| object \| array |
| `src/content/config.ts` | `systemSchemaJsonShape` accepts object \| array |
| `src/components/JsonLd.astro` | prop type widened to `unknown` (JSON.stringify handles either; search engines accept either) |

## Verification

- `tsc --noEmit` clean
- 36/36 tests passing
- `npm run build` still ships the placeholder (its `@graph` form remains one of the accepted shapes)

## Post-merge

Tyler re-comments `/funded generate The-Saucy-African` on issue #8. Third time's the charm — the precheck (PR #9) and the JSON-LD shape (this PR) are both fixed, so the pipeline should complete this round.

---
_Generated by [Claude Code](https://claude.ai/code/session_014jtP3vYDPkVZzTYPzLHMmq)_