### PR TITLE
fix(humanize): tighten prompt contract; one source of truth for thresholds

### DIFF
--- a/prompts/case-study-prompt.md
+++ b/prompts/case-study-prompt.md
@@ -698,7 +698,7 @@ The input `summary` is HTML the owner wrote on the Honeycomb platform and may co
 
 ## 12. Failure modes to avoid
 
-These are the patterns that either read as AI-generated or are blocked outright by the Wix humanization validator. The validator runs on every CMS insert/update; copy that trips it sets `humanizationChecked = false` and the page renders as 404 until a human edits it. Treat this section as absolute.
+These are the patterns that read as AI-generated. The validator in `scripts/lib/humanize.ts` runs after generation and rejects any draft that trips them — no MDX is written, the tracking issue gets the `error` label, and the case study fails to generate. Treat this section as absolute.
 
 The validator covers `story` and `metaDescription`. The other text fields are not validated but should follow the same rules — a reviewer reading them will smell AI even if the regex won't catch it.
 
@@ -873,8 +873,8 @@ For each item below, scan your `story` and `metaDescription` and confirm zero vi
 2. **Hedge phrases (Section 12.1).** Zero occurrences of any phrase in the §12.1 list.
 3. **"Not just/only/merely/simply X but Y" (Section 12.1).** Zero occurrences. Search for "not just", "not only", "not merely", "not simply".
 4. **Generic openers (Section 12.3).** First sentence of `story` does not begin with any of: {{HUMANIZATION_BANNED_OPENERS}}.
-5. **Em-dash count.** Count the em-dashes (`—`) in `story`. With an 800–1,200 word body, more than {{HUMANIZATION_EM_DASH_THRESHOLD}} per 500 words trips the cap. Target zero or one across the whole body.
-6. **Tricolon count.** Count "X, Y, and Z" patterns where each item is 1–3 words. More than {{HUMANIZATION_TRICOLON_THRESHOLD}} per 500 words trips the cap. Target zero or one across the whole body.
+5. **Em-dash count.** Count the em-dashes (`—`) in `story`. With an 800–1,200 word body, more than {{HUMANIZATION_EM_DASH_THRESHOLD}} per 500 words trips the cap.
+6. **Tricolon count.** Count "X, Y, and Z" patterns where each item is 1–3 words. More than {{HUMANIZATION_TRICOLON_THRESHOLD}} per 500 words trips the cap.
 7. **Sentence rhythm (Section 12.6.6).** Confirm at least 3 sentences under 8 words, at least 1 sentence over 25 words, and at least one single-sentence paragraph.
 
 If after a fix you find yourself second-guessing the rewrite, prefer a shorter, plainer version. A blunt sentence that lands beats a clever one that trips a rule.
@@ -896,8 +896,8 @@ Before emitting the output JSON, verify every item below. If any check fails, fi
 9. **Story contains only allowlisted HTML tags** (Section 11). No `<div>`, no `<img>`, no inline styles, no class attributes.
 10. **First sentence of story passes opening check** (Section 12.3).
 11. **Scan story and metaDescription for every blocked phrase and word** (Sections 12.1, 12.2). Zero occurrences.
-12. **Count em-dashes in story.** Should be 0 or 1.
-13. **Count tricolons (A, B, and C patterns with 1–3 word items) in story.** Should be 0–2 across the whole story, regardless of length.
+12. **Count em-dashes in story.** More than {{HUMANIZATION_EM_DASH_THRESHOLD}} per 500 words trips the cap.
+13. **Count tricolons (A, B, and C patterns with 1–3 word items) in story.** More than {{HUMANIZATION_TRICOLON_THRESHOLD}} per 500 words trips the cap.
 14. **Company name everywhere is "Honeycomb Credit" or "Honeycomb"** — no "HoneyComb," "Honey Comb," or other casings.
 15. **No invented facts.** Every concrete claim traces back to the input payload.
 16. **No fabricated quotes** unless verbatim in `summary`.

--- a/scripts/lib/humanize.test.ts
+++ b/scripts/lib/humanize.test.ts
@@ -4,8 +4,11 @@
 // Density-checked rules verify both above- and below-threshold behavior.
 // =============================================================================
 
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { validateCopy, stripHtml, formatIssuesForReviewer } from './humanize.js';
+import { applyPromptSubstitutions } from './humanization-rules.js';
 
 // ~500 words, deliberately written to avoid every AI tell pattern. Used as
 // the baseline that should pass cleanly. Density-edge tests append small
@@ -148,6 +151,18 @@ describe('stripHtml', () => {
   });
   it('collapses whitespace', () => {
     expect(stripHtml('<p>a</p>\n\n<p>b</p>')).toBe('a b');
+  });
+});
+
+describe('applyPromptSubstitutions', () => {
+  // Guards against adding `{{HUMANIZATION_FOO}}` to the prompt without
+  // adding a matching entry to PromptSubstitutions. An unfilled placeholder
+  // would silently leak into the system prompt sent to Claude.
+  it('substitutes every {{HUMANIZATION_*}} placeholder in the runtime prompt', async () => {
+    const promptPath = path.resolve(process.cwd(), 'prompts/case-study-prompt.md');
+    const raw = await fs.readFile(promptPath, 'utf8');
+    const substituted = applyPromptSubstitutions(raw);
+    expect(substituted).not.toMatch(/\{\{HUMANIZATION_/);
   });
 });
 


### PR DESCRIPTION
## Summary

Three audit findings on the 10f3714 humanization circuit-breaker, shipped together so the single-source-of-truth invariant is restored in one step.

- **§12 intro rewritten.** The stale Wix-era copy ("blocked outright by the Wix humanization validator … `humanizationChecked = false` … page renders as 404") directly contradicted §13.5's circuit-breaker framing. New text describes the actual runtime: the validator in `scripts/lib/humanize.ts` rejects the draft, no MDX is written, and the tracking issue gets the `error` label.
- **§14 items 12–13 + §13.5 items 5–6 templated.** Hardcoded "0 or 1" / "0–2" counts replaced with `{{HUMANIZATION_EM_DASH_THRESHOLD}}` / `{{HUMANIZATION_TRICOLON_THRESHOLD}}`. Also dropped the "Target zero or one across the whole body" trailer in §13.5 — same leak in fresh prose from the same commit. Threshold edits in `humanization-rules.ts` now propagate to the final checklist too.
- **Placeholder-completeness test added.** Reads the runtime prompt, runs `applyPromptSubstitutions`, asserts no `{{HUMANIZATION_` survives. Catches future placeholder typos at CI time before they leak into the system prompt.

§12.4 descriptive prose ("safe target" language) left alone — pre-existing, out of audit scope. Other Wix-era cosmetic references (lines 6, 65, 203, 674) are far from the edit window and stay as backlog.

## Test plan

- [ ] `npm test` — the new test in `humanize.test.ts` passes against the substituted prompt
- [ ] `npm run typecheck` — clean
- [ ] Spot-check the rendered prompt: `npx tsx -e 'import("./scripts/lib/humanization-rules.js").then(({applyPromptSubstitutions}) => fs.readFile("prompts/case-study-prompt.md","utf8").then(r => console.log(applyPromptSubstitutions(r))))' | grep HUMANIZATION_` returns empty
- [ ] Next live generation: confirm the model isn't echoing the Wix-era language back in any way (it never should, but worth eyeballing one)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rq8oYvU2kkzfHt6yMA4A7c)_