### PR TITLE
fix(cron): schedule detect at two daily slots for reliability

### DIFF
--- a/.github/workflows/detect.yml
+++ b/.github/workflows/detect.yml
@@ -8,14 +8,21 @@ name: Detect
 
 on:
   schedule:
-    # 08:13 UTC daily = 04:13 EDT / 03:13 EST. Earliest reasonable
-    # off-peak slot: avoids GitHub Actions' busiest cron windows (00 UTC,
-    # 12 UTC, and any top-of-hour boundary), runs while Tyler's morning
-    # is still pre-dawn so a successful run is waiting in the inbox.
-    # Previous 12:07 UTC slot saw routine 25–30 min delays from cron
-    # contention near noon UTC; 08:xx slots typically dispatch within
-    # 5 min. Off-the-hour minute (:13) further reduces delay risk.
-    - cron: '13 8 * * *'
+    # Two daily slots. GitHub Actions silently drops or delays scheduled
+    # workflows during high-load periods, and we cannot predict which slots
+    # will be hit on a given day. The script is idempotent — already-
+    # published campaigns are filtered out by `listAllCampaignSlugs()`
+    # before any rate-limit consumption — so running twice/day costs nothing
+    # when the first run lands cleanly, and rescues the day when it doesn't.
+    #
+    # Empirical track record (last 5 days):
+    #   12:07 UTC slot — fired within 30 min (1 sample)
+    #   08:13 UTC slot — fired 3+ hours late on 2 of 3 days, dropped on day 3
+    #
+    # 04:47 UTC = 00:47 EDT (overnight, low GH contention).
+    # 11:23 UTC = 07:23 EDT (mid-morning backup, off the :00/:30 spikes).
+    - cron: '47 4 * * *'
+    - cron: '23 11 * * *'
   workflow_dispatch:
     inputs:
       dry-run:


### PR DESCRIPTION
## What's broken

Today's detect cron didn't fire. PR #44's 08:13 UTC slot was sold as "earliest off-peak" — empirically it's been the opposite:

| Date | Scheduled | Actually fired | Delay |
|---|---|---|---|
| 2026-05-09 | 08:13 UTC | 11:19 UTC | 3h06m |
| 2026-05-10 | 08:13 UTC | 11:33 UTC | 3h20m |
| 2026-05-11 | 08:13 UTC | *not yet at 16:39 UTC* | 8h+ (dropped) |

The original 12:07 UTC slot fired within ~30 min. The "off-peak" hypothesis was wrong; in this account 08:xx is empirically worse, not better.

## What this changes

Two daily slots at off-the-hour minutes, off the GH cron contention spikes:

```yaml
- cron: '47 4 * * *'   # 04:47 UTC = 00:47 EDT — overnight, low load
- cron: '23 11 * * *'  # 11:23 UTC = 07:23 EDT — backup near the 12:07 slot that was working
```

The pipeline is idempotent — `listAllCampaignSlugs()` filters already-published candidates before rate-limit consumption. So the second slot costs $0 when the first lands cleanly and rescues the day when it doesn't.

## One action for Tyler

This PR won't fix **today**. Today's cron didn't fire and I cannot dispatch workflows from this session. Click **Run workflow** on `.github/workflows/detect.yml` in the Actions tab to backfill 5/11.

## Test plan

- [ ] Merge → both crons appear in the Actions tab schedule
- [ ] Tomorrow's 04:47 UTC run lands within ~30 min and appends to `.state/detection-log.md`
- [ ] If 04:47 is delayed/dropped, the 11:23 UTC run catches it


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rq8oYvU2kkzfHt6yMA4A7c)_