### PR TITLE
docs: fix stale documentation (cron schedule, test count, Wix CMS refs, token estimates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ the case studies live as MDX files in this repo.
 
 ```
        ┌────────────────────────┐
-       │   noon-UTC cron        │  detect.yml — queries PostHog (Fivetran-mirrored
+       │   twice-daily cron     │  detect.yml — queries PostHog (Fivetran-mirrored
        │   (detect.yml)         │  postgres.campaigns) for funded slugs ≥ 2026-01-01,
        └────────────┬───────────┘  filters out already-published, newest first.
+                                   Slots: 04:47 UTC (overnight) + 11:23 UTC (backup).
                     │
                     ▼
        ┌────────────────────────┐  scripts/lib/pipeline.ts
@@ -52,7 +53,7 @@ The full operator README — quickstart, sharing access, costs, troubleshooting,
 - **GitHub Pages** from a private repo (GitHub Pro)
 - **GitHub Actions** for cron, on-comment dispatcher, on-issue dispatcher, deploy
 - **Anthropic SDK** with Claude Opus 4.7 for generation (~$0.45 per case study)
-- **Vitest** for unit tests; `astro sync && tsc --noEmit` + 57-test suite gate every deploy
+- **Vitest** for unit tests; `astro sync && tsc --noEmit` + 65-test suite gate every deploy
 
 ## Local development
 
@@ -62,7 +63,7 @@ npm install
 npm run dev        # http://localhost:4321
 npm run build      # static output to dist/
 npm run typecheck  # astro sync && tsc --noEmit
-npm test           # vitest run (57 tests)
+npm test           # vitest run (65 tests)
 ```
 
 Running the agent CLIs locally needs `ANTHROPIC_API_KEY` and `GITHUB_TOKEN` in env. In CI both are wired up via repo secrets and `secrets.GITHUB_TOKEN`.

--- a/prompts/case-study-prompt.md
+++ b/prompts/case-study-prompt.md
@@ -3,7 +3,7 @@
 > **System/user prompt sent to the Claude API by the Collateral Development Agent for every newly-funded Honeycomb Credit campaign.**
 > The agent provides the input payload (Section 3) immediately after this prompt. You must return the output JSON (Section 4) with no preamble, no markdown fencing, and no commentary. Your entire response must parse as JSON on first attempt.
 >
-> **Version:** aligned with Collateral Agent spec v3.3. Output keys map 1:1 to Wix CMS field IDs in the `CaseStudies` collection.
+> **Version:** aligned with Collateral Agent spec v3.3. Output keys map 1:1 to MDX frontmatter fields defined in `src/content/config.ts` (Astro content collection).
 
 ---
 
@@ -62,7 +62,7 @@ The user message that follows this prompt contains a single JSON object scraped 
 
 ## 4. Output schema
 
-Return a single JSON object with exactly these top-level keys, in this order, and nothing else. Each key maps 1:1 to a Wix CMS field ID.
+Return a single JSON object with exactly these top-level keys, in this order, and nothing else. Each key maps 1:1 to a frontmatter field in the published MDX file (validated by the Astro content collection schema in `src/content/config.ts`).
 
 ```json
 {
@@ -682,7 +682,7 @@ If you suspect a slug may already exist (e.g., a second Nomad Donuts), append on
 
 ## 11. Rich-text HTML rules
 
-The `story` field is stored in a Wix rich-text field and rendered inside a `<div>` the template controls. Only a subset of HTML is accepted; anything outside the allowlist is stripped at render time.
+The `story` field is written as HTML into an MDX file and rendered by the Astro layout (`src/layouts/CaseStudy.astro`). Only a subset of HTML is accepted; tags outside the allowlist are stripped or misrendered at build time.
 
 **Allowlist (use freely):** `<p>`, `<h2>`, `<h3>`, `<h4>`, `<h5>`, `<h6>`, `<a>`, `<b>`, `<strong>`, `<i>`, `<em>`, `<u>`, `<ul>`, `<ol>`, `<li>`, `<br>`, `<span>`.
 

--- a/scripts/cost-estimate.ts
+++ b/scripts/cost-estimate.ts
@@ -34,7 +34,7 @@ async function main(): Promise<void> {
     '',
     `Slugs: ${slugs.map((s) => `\`${s}\``).join(', ')}`,
     '',
-    `Estimate is based on a typical input of ~8000 tokens and a typical output of ~2000 tokens at the active model's published rate. Actual cost varies with the campaign's summary length.`,
+    `Estimate is based on a typical input of ~17,000 tokens (prompt ~14k + campaign payload ~3k) and a typical output of ~2,800 tokens at the active model's published rate. Actual cost varies with the campaign's summary length.`,
   ].join('\n');
 
   await stage(body);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Four documentation inaccuracies found during a full repo review and corrected:

- **`README.md` — cron schedule:** The architecture diagram said "noon-UTC cron" but `detect.yml` was updated to two daily slots (04:47 UTC overnight + 11:23 UTC backup). Updated to "twice-daily cron" with both slot times noted.
- **`README.md` — test count:** "57-test suite" was stale; the actual `it()` count across the five `.test.ts` files is 65. Updated in both the Stack section and the local dev command.
- **`prompts/case-study-prompt.md` — Wix CMS references:** Three places in the prompt described the output destination as "Wix CMS field IDs" and "Wix rich-text field." The system runs on Astro + MDX, not Wix. Updated to reference the Astro content collection schema (`src/content/config.ts`) and the `CaseStudy.astro` layout.
- **`scripts/cost-estimate.ts` — token estimate in user-visible message:** The cost disclaimer shown to operators said "~8000 input tokens, ~2000 output" but `estimateCostForGeneration()` in `claude.ts` uses 17,000 / 2,800 (calibrated against real Opus 4.7 generations). Corrected to match.

## Test plan

- [ ] No logic changed; diff is documentation only
- [ ] `README.md` changes are factually consistent with `detect.yml` cron schedule and actual test file contents
- [ ] Prompt changes remove Wix references without altering any generation rule or constraint

https://claude.ai/code/session_014XScfgcQdKUG9YqQ8poSAg
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014XScfgcQdKUG9YqQ8poSAg)_