### PR TITLE
docs: align documentation with actual system behavior

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,19 @@ ANTHROPIC_API_KEY=
 # Optional. Local-only: token used by scripts/lib/github.ts when running scripts
 # outside CI. In CI, GITHUB_TOKEN is provided automatically.
 GITHUB_TOKEN=
+
+# Required for scripts/detect.ts (the daily cron entry point).
+# Personal API key with project:query:read scope on the PostHog project.
+# In CI, these are supplied by the POSTHOG_API_KEY and POSTHOG_PROJECT_ID
+# repo secrets (Settings → Secrets → Actions).
+POSTHOG_API_KEY=
+POSTHOG_PROJECT_ID=
+
+# Optional. PostHog cloud region. Defaults to https://us.posthog.com.
+# Set to https://eu.posthog.com if the project is on the EU cloud.
+# POSTHOG_HOST=https://us.posthog.com
+
+# Optional. Override the Claude model used for generation.
+# Defaults to claude-opus-4-7. Useful for cheaper local testing.
+# Valid values: claude-opus-4-7, claude-sonnet-4-6, claude-haiku-4-5-20251001
+# CASE_STUDY_MODEL=claude-sonnet-4-6

--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ the case studies live as MDX files in this repo.
 
 ```
        ┌────────────────────────┐
-       │   noon-UTC cron        │  detect.yml — queries PostHog (Fivetran-mirrored
+       │   two daily cron slots │  detect.yml — queries PostHog (Fivetran-mirrored
        │   (detect.yml)         │  postgres.campaigns) for funded slugs ≥ 2026-01-01,
        └────────────┬───────────┘  filters out already-published, newest first.
                     │
                     ▼
        ┌────────────────────────┐  scripts/lib/pipeline.ts
        │   per-slug pipeline    │  scrape → Claude (prompts/case-study-prompt.md)
-       │                        │  → humanization validator → image fetch
-       └────────────┬───────────┘  → MDX commit → push.
-                    │
+       │                        │  → humanization validator (retry once on fail,
+       └────────────┬───────────┘    then publish anyway) → image fetch
+                    │              → MDX commit → push.
                     ▼
        ┌────────────────────────┐  deploy.yml — Astro build, GitHub Pages deploy.
        │   site rebuild         │  Live within ~2 min of any commit to main.
@@ -52,7 +52,7 @@ The full operator README — quickstart, sharing access, costs, troubleshooting,
 - **GitHub Pages** from a private repo (GitHub Pro)
 - **GitHub Actions** for cron, on-comment dispatcher, on-issue dispatcher, deploy
 - **Anthropic SDK** with Claude Opus 4.7 for generation (~$0.45 per case study)
-- **Vitest** for unit tests; `astro sync && tsc --noEmit` + 57-test suite gate every deploy
+- **Vitest** for unit tests; `astro sync && tsc --noEmit` + 65-test suite gate every deploy
 
 ## Local development
 
@@ -62,10 +62,10 @@ npm install
 npm run dev        # http://localhost:4321
 npm run build      # static output to dist/
 npm run typecheck  # astro sync && tsc --noEmit
-npm test           # vitest run (57 tests)
+npm test           # vitest run (65 tests)
 ```
 
-Running the agent CLIs locally needs `ANTHROPIC_API_KEY` and `GITHUB_TOKEN` in env. In CI both are wired up via repo secrets and `secrets.GITHUB_TOKEN`.
+Running the agent CLIs locally needs `ANTHROPIC_API_KEY` and `GITHUB_TOKEN` in env (copy `.env.example` and fill in values). The detect cron also requires `POSTHOG_API_KEY` and `POSTHOG_PROJECT_ID`; in CI these are wired up via repo secrets.
 
 ```bash
 npx tsx scripts/inspect.ts <slug>            # diagnostic, no spend
@@ -75,6 +75,8 @@ npx tsx scripts/delete.ts <slug>
 npx tsx scripts/backfill.ts --slugs="A\nB\nC" [--force] [--dry-run] [--rate=N]
 npx tsx scripts/detect.ts [--dry-run]        # the cron entry point
 ```
+
+Model override (defaults to `claude-opus-4-7`): set `CASE_STUDY_MODEL` to any value from `scripts/lib/claude.ts` PRICING table (e.g. `claude-sonnet-4-6` for cheaper local testing).
 
 ## Repo layout
 
@@ -109,7 +111,7 @@ scripts/
 .github/
   workflows/
     deploy.yml            ← Astro build + Pages deploy on push to main
-    detect.yml            ← cron at 12:07 UTC daily
+    detect.yml            ← two daily cron slots (04:47 UTC and 11:23 UTC)
     on-comment.yml        ← /funded slash dispatcher
     on-issue.yml          ← Issue Form dispatcher (routes by title prefix)
   ISSUE_TEMPLATE/
@@ -125,7 +127,7 @@ prompts/
 
 | File | What it shows | Created when |
 |---|---|---|
-| [`.state/detection-log.md`](.state/detection-log.md) | Daily cron heartbeat (one row per run; PostHog-returned / already-published / eligible / generated / rate-limit deferred / failed) | First 12:07-UTC cron run after PR #29; appended thereafter |
+| [`.state/detection-log.md`](.state/detection-log.md) | Daily cron heartbeat (one row per run; PostHog-returned / already-published / eligible / generated / rate-limit deferred / failed) | First cron run after PR #29; appended thereafter |
 
 > ⚠ `.state/ratelimit.json` is written by `consume()` during a workflow run but **not currently committed**. See "Known gaps" below.
 
@@ -138,6 +140,18 @@ Three layered Zod schemas, each gating a different boundary:
 | `scripts/lib/schemas.ts` `CampaignSchema` | Honeycomb scrape payload | Scrape fails, tracking issue gets `error` label |
 
 When Honeycomb's `__NEXT_DATA__` shape changes, the third schema is what catches it — defensive parsing with explicit field-presence checks.
+
+### Humanization validator — soft gate with retry
+
+`scripts/lib/humanize.ts` runs regex checks for AI-writing tells (banned vocabulary, hedge phrases, em-dash overuse, tricolon density, etc.) against the generated story text. The pipeline calls the validator after every Claude response, with the following retry policy:
+
+1. **Attempt 1** — generate normally.
+2. **If validation fails**, re-call Claude with the validator's flagged issues spliced into the prompt as targeted feedback (attempt 2).
+3. **If attempt 2 also fails** — publish anyway and apply a `humanization-warning` label to the tracking issue. The case study is live but flagged for review.
+
+This two-strikes-and-publish policy replaced a hard-gate approach after issues #39 and #41, where real funded campaigns produced no published case study at all. Operators should monitor for `humanization-warning` labels and redraft those pages.
+
+> Note: `prompts/case-study-prompt.md §13.5` still describes the validator as a hard gate — this framing is intentional motivation for Claude on each attempt. Claude should not be aware of the system-level publish fallback.
 
 ## Cost and rate model
 
@@ -153,5 +167,7 @@ Rate limit: **3/day** across all triggers (cron + manual + portal). Backfill iss
 ## Known gaps
 
 - **Founder-level input data.** Current input payload (campaign summary + use-of-proceeds + metrics) doesn't include the founder's name, photo, or verbatim Q&A. The "Ask The Founders" tab on each campaign page would unlock this and is the single biggest quality lever still on the roadmap. See `prompts/case-study-prompt.md` §6 for what the prompt does to compensate today.
-- **Rate-limit persistence is per-run, not per-day.** `consume()` in `scripts/lib/ratelimit.ts` writes `.state/ratelimit.json` but the workflows don't commit it back to the repo, so each new workflow invocation starts with a fresh 0-of-3 budget. In practice this hasn't caused over-spend (the cron runs once per day; backfill caps itself; manual ops are infrequent) but the documented "3/day across all triggers" semantic is more permissive than intended. Fix is small (add the file to per-slug commits in `pipeline.ts`); race conditions to think through if multiple workflows overlap.
+- **Investment structure not scraped.** The runtime prompt (§13, grounding rule for investment structure) instructs Claude to use different phrasing for `Debt` vs `Revenue Share` vs `Preferred Equity` offerings. However, `investmentType`, `annualInterestRate`, and `loanDuration` are not yet extracted from `__NEXT_DATA__` or passed to Claude. Claude defaults to neutral "Honeycomb raise" / "community-funded raise" language when these fields are absent. In practice this is acceptable while Honeycomb's portfolio is predominantly debt raises; it becomes a compliance risk if Revenue Share or Equity offerings publish with loan terminology. Fix: add the fields to `CampaignSchema` in `scripts/lib/schemas.ts`, plumb them through `InputPayload` in `scripts/lib/claude.ts`, and update the prompt's §3 input schema.
+- **`issuer.businessType` not passed to Claude.** The Honeycomb platform's broad industry category (`issuer.businessType`) is in `CampaignSchema` but is not included in the payload sent to Claude. The prompt's §8 keyword-tag rules note it as "a hint — not the source of truth," so this is low-impact, but completing the scrape would give Claude better industry context.
+- **Rate-limit persistence is per-run, not per-day.** `consume()` in `scripts/lib/ratelimit.ts` writes `.state/ratelimit.json` but the workflows don't commit it back to the repo, so each new workflow invocation starts with a fresh 0-of-3 budget. In practice this hasn't caused over-spend (the cron runs at most twice per day; backfill caps itself; manual ops are infrequent) but the documented "3/day across all triggers" semantic is more permissive than intended. Fix is small (add the file to per-slug commits in `pipeline.ts`); race conditions to think through if multiple workflows overlap.
 - **Pre-2026 historical campaigns are not auto-published.** The PostHog detection query floors at `campaignexpirationdate >= '2026-01-01'`. ~570 historical funded campaigns are visible to PostHog but intentionally skipped by the cron — Tyler will hand-pick any he wants published via the Backfill Issue Form.

--- a/prompts/case-study-prompt.md
+++ b/prompts/case-study-prompt.md
@@ -31,32 +31,30 @@ Every narrative, SEO, and CTA choice on the page exists to serve this reader and
 
 ## 3. Input schema
 
-The user message that follows this prompt contains a single JSON object scraped from the closed campaign's `invest.honeycombcredit.com/campaigns/{slug}` page, plus an agent-injected `todayISO` field. Treat every value as the only source of ground truth you have about this business. If a field is missing or empty, do not invent a replacement.
+The user message that follows this prompt contains a single JSON object scraped from the closed campaign's `invest.honeycombcredit.com/campaigns/{slug}` page, plus agent-injected fields. Treat every value as the only source of ground truth you have about this business. If a field is missing or absent from the object, do not invent a replacement — follow the grounding rule in Section 13.
 
 ```json
 {
   "campaignName": "string — the display name of the campaign, e.g. \"Brothmonger\"",
-  "slug": "string — the Honeycomb URL slug, e.g. \"Brothmonger-Brooklyn-Bone-Broth\". Do NOT reuse this as the case-study slug.",
-  "issuer": {
-    "businessType": "string — broad industry category from Honeycomb's form, e.g. \"Food & Beverage\"",
-    "city": "string — e.g. \"Brooklyn\"",
-    "state": "string — two-letter abbrev, e.g. \"NY\"",
-    "description": "string — short business description the owner wrote",
-    "website": "string — URL, may be empty"
-  },
+  "campaignSlug": "string — the Honeycomb platform URL slug, e.g. \"Brothmonger-Brooklyn-Bone-Broth\". Do NOT reuse this as the case-study slug.",
+  "campaignId": "string — Honeycomb's internal campaign identifier. Use in systemSchemaJson @id if needed.",
+  "todayISO": "string — ISO date injected by the agent at call time, e.g. \"2026-04-24\". Use this in systemSchemaJson as datePublished.",
+  "city": "string — e.g. \"Brooklyn\"",
+  "state": "string — two-letter uppercase abbrev, e.g. \"NY\"",
   "summary": "string — HTML narrative the business wrote during their raise. Often 500–2000 words. May contain any HTML. Treat as primary factual source for the story.",
-  "useOfProceeds": "string — what the business said they would spend the money on",
+  "useOfProceeds": "string — what the business said they would spend the money on (optional, may be absent)",
+  "issuerDescription": "string — short business description the owner wrote on the Honeycomb platform (optional, may be absent)",
+  "issuerWebsite": "string — business website URL (optional, may be absent or empty)",
+  "ogImageUrl": "string — canonical OG/hero image URL for the campaign (optional, may be absent). Use in systemSchemaJson `image` fields when present.",
   "totalFundsRaised": "number — e.g. 100000",
-  "campaignTargetAmount": "number — the goal, e.g. 75000",
+  "campaignTargetAmount": "number — the fundraising goal, e.g. 75000",
   "numInvestors": "number — e.g. 117",
   "campaignStartDate": "string — ISO date, e.g. \"2025-10-14\"",
-  "campaignExpirationDate": "string — ISO date, e.g. \"2025-11-04\"",
-  "investmentType": "string — e.g. \"Debt\"",
-  "annualInterestRate": "number or null — e.g. 10",
-  "loanDuration": "string or null — e.g. \"36 months\"",
-  "todayISO": "string — ISO date injected by the agent at call time, e.g. \"2026-04-24\". Use this in systemSchemaJson as datePublished."
+  "campaignExpirationDate": "string — ISO date, e.g. \"2025-11-04\""
 }
 ```
+
+> **Note on investment structure fields.** `investmentType`, `annualInterestRate`, and `loanDuration` are not currently included in the input payload. When absent, default to neutral terms — "Honeycomb raise" or "community-funded raise" — rather than loan-specific language. See Section 13 for the full grounding rule on investment structure.
 
 ---
 
@@ -883,7 +881,7 @@ Cases requiring particular care:
 - **Investor identities.** You may describe investors as "regulars," "neighbors," "customers," "local families," etc. *only* if `summary` or `issuer.description` supports that characterization. If the input is silent on who the investors were, say "117 investors" and move on.
 - **Quotes.** See Section 12.5. Never fabricate.
 - **Outcomes.** `useOfProceeds` tells you what the business said they *would* do with the money. You may say "the funds went toward X." You may not say "the new kitchen is now serving Y customers a week" unless that is explicitly in the input.
-- **Investment structure.** The `investmentType` field may be `Debt`, `Revenue Share`, `Preferred Equity`, or another structure. Use the phrase *"fixed-rate, fixed-term community-funded loan"* only when `investmentType` is `Debt`. For `Revenue Share`, use *"community-funded revenue share offering"* or *"community-backed revenue share"*. For `Preferred Equity`, use *"community-funded preferred equity raise"* or *"community-backed raise"*. When in doubt, fall back to the neutral terms *"Honeycomb raise"* or *"community-funded raise"* — both are always accurate. Never describe a non-Debt offering as a loan. This is a compliance-adjacent error, not a style preference.
+- **Investment structure.** The `investmentType` field (`Debt`, `Revenue Share`, `Preferred Equity`) is not currently included in the input payload (see §3 note). Default to the neutral terms *"Honeycomb raise"* or *"community-funded raise"* when the investment type is unknown — both are always accurate. If context clues in `summary` or `useOfProceeds` make the structure clear (e.g., the owner explicitly mentions "loan" or "revenue share"), you may use more specific language: *"fixed-rate, fixed-term community-funded loan"* for debt raises, *"community-funded revenue share offering"* for revenue share, *"community-funded preferred equity raise"* for equity. Never describe a non-Debt offering as a loan on contextual evidence alone — when in doubt, use neutral terms. This is a compliance-adjacent rule, not a style preference.
 - **Dates.** Use `campaignStartDate` and `campaignExpirationDate` to describe the raise window. Do not predict when a project will open unless the input gives a date.
 - **Location.** Use the `city` and `state` from the input payload verbatim in `h1Heading`, `metaTitle`, `metaDescription`, and the body's first mention. Do not substitute a nearby MSA or larger metro for the named city (e.g., do not write "Huntsville, AL" when the input says "Madison, AL," even if Madison is part of the Huntsville MSA). The header chip and structured-data fields render directly from the input — if the body names a different city, the page contradicts itself.
 
@@ -948,25 +946,21 @@ Study the shape.
 ```json
 {
   "campaignName": "Brothmonger",
-  "slug": "Brothmonger-Brooklyn-Bone-Broth",
-  "issuer": {
-    "businessType": "Food & Beverage",
-    "city": "Brooklyn",
-    "state": "NY",
-    "description": "Small-batch bone broth and seasonal soups, sold at the Grand Army Plaza Greenmarket since 2018.",
-    "website": "https://brothmonger.com"
-  },
+  "campaignSlug": "Brothmonger-Brooklyn-Bone-Broth",
+  "campaignId": "cmp_brothmonger_001",
+  "todayISO": "2026-04-24",
+  "city": "Brooklyn",
+  "state": "NY",
+  "issuerDescription": "Small-batch bone broth and seasonal soups, sold at the Grand Army Plaza Greenmarket since 2018.",
+  "issuerWebsite": "https://brothmonger.com",
+  "ogImageUrl": "https://storage.googleapis.com/honeycomb-uploads/brothmonger-hero.jpg",
   "summary": "<p>Brothmonger started in 2018 as a folding table at the Grand Army Plaza Greenmarket. Sarah Chen cooked everything out of a rented commissary kitchen in Gowanus and loaded Cambros into her station wagon every Saturday morning. The menu was two flavors at first: a 24-hour chicken and a 48-hour beef.</p><p>Six years in, the business had regulars who brought friends, friends who brought coworkers, and a growing list of wholesale accounts — yoga studios, a hospital cafeteria, two specialty grocers in Brooklyn. The commissary was the constraint. We could not grow wholesale without our own kitchen, and we could not keep up with our own retail demand in someone else's kitchen either.</p><p>We talked to two banks. Neither wanted to underwrite a business whose books lived largely on Square and Stripe. We did not want to give up equity. We wanted to stay ours.</p><p>A longtime regular told us about Honeycomb. The pitch made sense immediately — raise capital from the people who already buy broth every Saturday, pay them back with interest, keep the business whole. We launched in October 2025 and closed the raise in 21 days at $100,000 against a $75,000 goal, with 117 investors. Two of them have been regulars since 2019.</p><p>The money is going toward a lease and build-out of our first kitchen in Crown Heights, commercial equipment, and initial inventory for the expanded wholesale program.</p>",
   "useOfProceeds": "Lease deposit and build-out for first dedicated kitchen in Crown Heights; commercial stock pots, a 60-gallon tilt kettle, and walk-in refrigeration; initial wholesale inventory.",
   "totalFundsRaised": 100000,
   "campaignTargetAmount": 75000,
   "numInvestors": 117,
   "campaignStartDate": "2025-10-14",
-  "campaignExpirationDate": "2025-11-04",
-  "investmentType": "Debt",
-  "annualInterestRate": 10,
-  "loanDuration": "36 months",
-  "todayISO": "2026-04-24"
+  "campaignExpirationDate": "2025-11-04"
 }
 ```
 

--- a/scripts/lib/humanize.ts
+++ b/scripts/lib/humanize.ts
@@ -1,12 +1,19 @@
 // =============================================================================
-// Humanization validator — circuit breaker for AI-writing tells.
+// Humanization validator — AI-writing tell detector.
 //
 // Detects common AI-writing tells in long-form copy. Regex-based floor, not
-// a semantic analyzer. Called by pipeline.ts as a hard gate: a flagged
-// generation does NOT publish — the pipeline throws PipelineError and the
-// tracking issue gets the `error` label. The model is expected to produce
-// clean copy on first pass; the validator's job is to refuse anything that
-// slips through.
+// a semantic analyzer. Called by pipeline.ts after every Claude response.
+//
+// Retry policy (see pipeline.ts):
+//   Attempt 1: generate normally, then validate.
+//   If validation fails: re-call Claude once with the flagged issues as
+//     targeted feedback (attempt 2).
+//   If attempt 2 also fails: publish anyway; caller applies a
+//     `humanization-warning` label to the tracking issue.
+//
+// This is a soft gate in practice. The runtime prompt (§13.5) still frames
+// the validator as a hard gate to motivate clean first-pass output — Claude
+// should not be aware of the publish fallback.
 //
 // All rules live in scripts/lib/humanization-rules.ts. That file is the
 // single source of truth — both this validator and the runtime prompt


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **README**: Fix five factual inaccuracies and add two new Known Gaps entries
- **`.env.example`**: Add four missing environment variables required by the cron
- **`humanize.ts`**: Correct header comment from "hard gate" to accurate soft-gate description
- **`prompts/case-study-prompt.md`**: Fix the input schema (§3), investment structure grounding rule (§13), and worked-example payload (§15.1) to match what the code actually sends to Claude

## What changed and why

### README
| Was | Now |
|---|---|
| "noon-UTC cron" / "cron at 12:07 UTC daily" | Two daily slots: 04:47 UTC and 11:23 UTC |
| 57-test suite gate | 65 tests (suite has grown) |
| No mention of humanization retry behavior | Documents the 2-attempt retry-then-publish policy and `humanization-warning` label |
| No mention of PostHog or model env vars in local dev | Added `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID`, `CASE_STUDY_MODEL` |
| Known gaps had no entry for investment structure | Added gap: `investmentType`/`annualInterestRate`/`loanDuration` not scraped or passed to Claude |
| Known gaps had no entry for `issuer.businessType` | Added gap: field scraped but not forwarded to Claude |

### `.env.example`
Was missing four vars needed to run the cron locally: `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID`, `POSTHOG_HOST` (optional), and `CASE_STUDY_MODEL` (optional override).

### `scripts/lib/humanize.ts`
Header comment described the validator as a "hard gate" — the pipeline actually retries once with targeted feedback and then publishes anyway with a `humanization-warning` label. The comment now accurately describes the soft-gate behavior.

### `prompts/case-study-prompt.md`
The §3 input schema was the most significant gap: it described a nested `issuer` object with `businessType`, `city`, `state`, `description`, `website`, plus `investmentType`, `annualInterestRate`, and `loanDuration` — none of which match the actual flat payload the code sends. Claude receives `city`, `state`, `issuerDescription`, `issuerWebsite` at the top level, plus `campaignSlug`, `campaignId`, and `ogImageUrl` which were not documented at all.

The §13 investment structure rule instructed Claude to branch on `investmentType`, but that field is never in the payload. The rule now defaults to neutral "Honeycomb raise" language and only permits loan/revenue-share/equity phrasing when the `summary` text itself makes the structure clear.

The §15.1 worked example was updated to show the actual payload shape.

## Test plan
- [ ] `npm test` passes (65 tests, no regressions)
- [ ] README renders correctly on GitHub
- [ ] Prompt changes don't break the humanization test suite (all regex rules still compile from humanization-rules.ts)

https://claude.ai/code/session_01Go5VUn4PQ6KjFZZNMZ8r5X
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Go5VUn4PQ6KjFZZNMZ8r5X)_