### PR TITLE
docs(readme): sync documentation with current codebase state

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,27 +7,29 @@ publishes a case study for every funded Honeycomb Credit campaign. The
 operators drive ad-hoc actions through GitHub Issues and a web portal, and
 the case studies live as MDX files in this repo.
 
+> **⏸ Daily cron is currently paused** (disabled 2026-06-09 to halt API spend while the project is on hold). Detection only runs via manual `workflow_dispatch` from the Actions tab. To resume automatic detection, uncomment the two `schedule:` cron lines in `.github/workflows/detect.yml` and push to main.
+
 | Surface | URL |
 |---|---|
 | **Live site** | https://funded.honeycombcredit.com |
 | **Operator portal** (you'll be here most of the time) | https://funded.honeycombcredit.com/admin |
 | **Audit log** (every action, every cron run) | https://github.com/tylerhoneycomb/case-study-generator/issues |
-| **Daily cron heartbeat** (no-email file log) | [`.state/detection-log.md`](.state/detection-log.md) |
+| **Detection-log heartbeat** (no-email file log) | [`.state/detection-log.md`](.state/detection-log.md) |
 
 ## How it works
 
 ```
        ┌────────────────────────┐
-       │   noon-UTC cron        │  detect.yml — queries PostHog (Fivetran-mirrored
-       │   (detect.yml)         │  postgres.campaigns) for funded slugs ≥ 2026-01-01,
+       │  04:47 + 11:23 UTC     │  detect.yml — queries PostHog (Fivetran-mirrored
+       │  cron (currently ⏸)   │  postgres.campaigns) for funded slugs ≥ 2026-01-01,
        └────────────┬───────────┘  filters out already-published, newest first.
                     │
                     ▼
        ┌────────────────────────┐  scripts/lib/pipeline.ts
        │   per-slug pipeline    │  scrape → Claude (prompts/case-study-prompt.md)
-       │                        │  → humanization validator → image fetch
-       └────────────┬───────────┘  → MDX commit → push.
-                    │
+       │                        │  → humanization validator (2-attempt retry, then
+       └────────────┬───────────┘  publish-with-warning) → image fetch
+                    │              → MDX commit → push.
                     ▼
        ┌────────────────────────┐  deploy.yml — Astro build, GitHub Pages deploy.
        │   site rebuild         │  Live within ~2 min of any commit to main.
@@ -52,7 +54,7 @@ The full operator README — quickstart, sharing access, costs, troubleshooting,
 - **GitHub Pages** from a private repo (GitHub Pro)
 - **GitHub Actions** for cron, on-comment dispatcher, on-issue dispatcher, deploy
 - **Anthropic SDK** with Claude Opus 4.7 for generation (~$0.45 per case study)
-- **Vitest** for unit tests; `astro sync && tsc --noEmit` + 57-test suite gate every deploy
+- **Vitest** for unit tests; `astro sync && tsc --noEmit` + 65-test suite gate every deploy
 
 ## Local development
 
@@ -62,7 +64,7 @@ npm install
 npm run dev        # http://localhost:4321
 npm run build      # static output to dist/
 npm run typecheck  # astro sync && tsc --noEmit
-npm test           # vitest run (57 tests)
+npm test           # vitest run (65 tests)
 ```
 
 Running the agent CLIs locally needs `ANTHROPIC_API_KEY` and `GITHUB_TOKEN` in env. In CI both are wired up via repo secrets and `secrets.GITHUB_TOKEN`.
@@ -99,7 +101,8 @@ scripts/
     posthog.ts            ← HogQL client — discovery source for funded slugs
     scrape.ts             ← __NEXT_DATA__ + HTML extraction (with hero-image fallbacks)
     claude.ts             ← Anthropic SDK wrapper, output validation
-    humanize.ts           ← AI-tells regex validator (port of velo_humanization.jsw)
+    humanize.ts           ← AI-tells regex validator; 2-attempt retry, then publish-with-warning
+    humanization-rules.ts ← shared banned phrases / density rules (also substituted into prompt)
     ratelimit.ts          ← 1/day default, 10/day backfill cap, UTC reset
     pipeline.ts           ← shared per-slug pipeline used by generate/redraft/backfill
     github.ts             ← Octokit wrappers (createIssue, addComment, etc.)
@@ -109,7 +112,7 @@ scripts/
 .github/
   workflows/
     deploy.yml            ← Astro build + Pages deploy on push to main
-    detect.yml            ← cron at 12:07 UTC daily
+    detect.yml            ← cron at 04:47 + 11:23 UTC daily (currently paused)
     on-comment.yml        ← /funded slash dispatcher
     on-issue.yml          ← Issue Form dispatcher (routes by title prefix)
   ISSUE_TEMPLATE/
@@ -125,7 +128,7 @@ prompts/
 
 | File | What it shows | Created when |
 |---|---|---|
-| [`.state/detection-log.md`](.state/detection-log.md) | Daily cron heartbeat (one row per run; PostHog-returned / already-published / eligible / generated / rate-limit deferred / failed) | First 12:07-UTC cron run after PR #29; appended thereafter |
+| [`.state/detection-log.md`](.state/detection-log.md) | Daily cron heartbeat (one row per run; PostHog-returned / already-published / eligible / generated / rate-limit deferred / failed) | First cron run after detection was wired up; appended on every subsequent run |
 
 > ⚠ `.state/ratelimit.json` is written by `consume()` during a workflow run but **not currently committed**. See "Known gaps" below.
 
@@ -143,7 +146,8 @@ When Honeycomb's `__NEXT_DATA__` shape changes, the third schema is what catches
 
 | Item | Cost |
 |---|---|
-| Generate or redraft | ~$0.45 per call (Opus 4.7, ~17K input + ~2.7K output tokens) |
+| Generate or redraft (clean path) | ~$0.45 per call (Opus 4.7, ~17K input + ~2.7K output tokens) |
+| Generate or redraft (humanization retry) | ~$0.90 max (two Claude calls if first draft fails the validator) |
 | Inspect / delete / status | $0 |
 | Astro build + Pages deploy | $0 (GitHub Actions free tier) |
 | Steady state at ~10 funded campaigns/month | ~$5/month |
@@ -152,6 +156,8 @@ Rate limit: **1/day** across all triggers (cron + manual + portal). Backfill iss
 
 ## Known gaps
 
+- **Daily cron is paused.** The `schedule:` triggers in `.github/workflows/detect.yml` are commented out (paused 2026-06-09). Detection only runs on `workflow_dispatch`. To resume, uncomment the two cron lines (04:47 UTC and 11:23 UTC) and push to main.
 - **Founder-level input data.** Current input payload (campaign summary + use-of-proceeds + metrics) doesn't include the founder's name, photo, or verbatim Q&A. The "Ask The Founders" tab on each campaign page would unlock this and is the single biggest quality lever still on the roadmap. See `prompts/case-study-prompt.md` §6 for what the prompt does to compensate today.
 - **Rate-limit persistence is per-run, not per-day.** `consume()` in `scripts/lib/ratelimit.ts` writes `.state/ratelimit.json` but the workflows don't commit it back to the repo, so each new workflow invocation starts with a fresh 0-of-1 budget. In practice this hasn't caused over-spend (the cron runs once per day; backfill caps itself; manual ops are infrequent) but the documented "1/day across all triggers" semantic is more permissive than intended. Fix is small (add the file to per-slug commits in `pipeline.ts`); race conditions to think through if multiple workflows overlap.
 - **Pre-2026 historical campaigns are not auto-published.** The PostHog detection query floors at `campaignexpirationdate >= '2026-01-01'`. ~570 historical funded campaigns are visible to PostHog but intentionally skipped by the cron — Tyler will hand-pick any he wants published via the Backfill Issue Form.
+- **Metrics strip shows three tiles only.** Progress-to-goal was removed as a headline figure; the raise outcome relative to target is covered in the narrative body when it carries weight (see `MetricsStrip.astro` and `prompts/case-study-prompt.md` §6 Beat 4).


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Audited the entire codebase against the README and corrected every discrepancy found.

- **Cron paused notice** — added a top-of-file callout and a Known Gaps entry noting the daily cron has been paused since 2026-06-09, with exact instructions to resume (uncomment two lines in `detect.yml`)
- **Cron schedule corrected** — README said "noon-UTC cron"; actual slots are 04:47 UTC and 11:23 UTC; updated the architecture diagram and the `detect.yml` annotation accordingly
- **Test count** — updated from 57 → 65 (5 test files now pass 65 assertions per `npm test`)
- **Humanization validator behavior** — the validator is a soft gate with a 2-attempt retry, not a hard stop; updated the pipeline diagram, the `humanize.ts` description, and the cost table (added ~$0.90 max row for retry path)
- **`humanization-rules.ts` added to repo layout** — the file exists in `scripts/lib/` but was missing from the layout listing
- **MetricsStrip change noted** — added Known Gap noting that progress-to-goal was removed as a headline figure
- **Stale PR-number reference removed** — detection-log "Created when" column no longer references PR #29

## Test plan

- [ ] `npm test` passes (65 tests)
- [ ] `npm run typecheck` passes
- [ ] README renders correctly on GitHub (check diagram alignment, table formatting)

https://claude.ai/code/session_013wFwBndvmWmJxjNKsLMgn6
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_013wFwBndvmWmJxjNKsLMgn6)_