### PR TITLE
docs: sync documentation with current codebase state

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ the case studies live as MDX files in this repo.
        │   noon-UTC cron        │  detect.yml — queries PostHog (Fivetran-mirrored
        │   (detect.yml)         │  postgres.campaigns) for funded slugs ≥ 2026-01-01,
        └────────────┬───────────┘  filters out already-published, newest first.
+                                   ⚠ Cron currently PAUSED (as of 2026-06-09).
+                                   Re-arm via Actions tab → Detect → Run workflow.
                     │
                     ▼
        ┌────────────────────────┐  scripts/lib/pipeline.ts
@@ -52,7 +54,7 @@ The full operator README — quickstart, sharing access, costs, troubleshooting,
 - **GitHub Pages** from a private repo (GitHub Pro)
 - **GitHub Actions** for cron, on-comment dispatcher, on-issue dispatcher, deploy
 - **Anthropic SDK** with Claude Opus 4.7 for generation (~$0.45 per case study)
-- **Vitest** for unit tests; `astro sync && tsc --noEmit` + 57-test suite gate every deploy
+- **Vitest** for unit tests; `astro sync && tsc --noEmit` + 65-test suite gate every deploy
 
 ## Local development
 
@@ -62,7 +64,7 @@ npm install
 npm run dev        # http://localhost:4321
 npm run build      # static output to dist/
 npm run typecheck  # astro sync && tsc --noEmit
-npm test           # vitest run (57 tests)
+npm test           # vitest run (65 tests)
 ```
 
 Running the agent CLIs locally needs `ANTHROPIC_API_KEY` and `GITHUB_TOKEN` in env. In CI both are wired up via repo secrets and `secrets.GITHUB_TOKEN`.
@@ -109,7 +111,7 @@ scripts/
 .github/
   workflows/
     deploy.yml            ← Astro build + Pages deploy on push to main
-    detect.yml            ← cron at 12:07 UTC daily
+    detect.yml            ← cron (PAUSED since 2026-06-09; re-arm via workflow_dispatch)
     on-comment.yml        ← /funded slash dispatcher
     on-issue.yml          ← Issue Form dispatcher (routes by title prefix)
   ISSUE_TEMPLATE/

--- a/prompts/case-study-prompt.md
+++ b/prompts/case-study-prompt.md
@@ -3,7 +3,7 @@
 > **System/user prompt sent to the Claude API by the Collateral Development Agent for every newly-funded Honeycomb Credit campaign.**
 > The agent provides the input payload (Section 3) immediately after this prompt. You must return the output JSON (Section 4) with no preamble, no markdown fencing, and no commentary. Your entire response must parse as JSON on first attempt.
 >
-> **Version:** aligned with Collateral Agent spec v3.3. Output keys map 1:1 to Wix CMS field IDs in the `CaseStudies` collection.
+> **Version:** aligned with Collateral Agent spec v4.0. Output keys map 1:1 to fields in the Astro content collection schema (`src/content/config.ts`).
 
 ---
 
@@ -62,7 +62,7 @@ The user message that follows this prompt contains a single JSON object scraped 
 
 ## 4. Output schema
 
-Return a single JSON object with exactly these top-level keys, in this order, and nothing else. Each key maps 1:1 to a Wix CMS field ID.
+Return a single JSON object with exactly these top-level keys, in this order, and nothing else. Each key maps 1:1 to a field in the Astro content collection schema (`src/content/config.ts`).
 
 ```json
 {
@@ -682,7 +682,7 @@ If you suspect a slug may already exist (e.g., a second Nomad Donuts), append on
 
 ## 11. Rich-text HTML rules
 
-The `story` field is stored in a Wix rich-text field and rendered inside a `<div>` the template controls. Only a subset of HTML is accepted; anything outside the allowlist is stripped at render time.
+The `story` field is stored as MDX body content and rendered inside a `<div>` the layout controls (`src/layouts/CaseStudy.astro`). Only a subset of HTML is accepted; anything outside the allowlist is stripped at render time.
 
 **Allowlist (use freely):** `<p>`, `<h2>`, `<h3>`, `<h4>`, `<h5>`, `<h6>`, `<a>`, `<b>`, `<strong>`, `<i>`, `<em>`, `<u>`, `<ul>`, `<ol>`, `<li>`, `<br>`, `<span>`.
 

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -87,8 +87,7 @@ const caseStudy = defineCollection({
 
       // ---------------------------------------------------------------------
       // Metrics. Numeric fields drive math; *Formatted fields drive display
-      // (Wix-era workaround preserved because the agent already produces them
-      // and they spare us a render-time formatter on every page).
+      // (pre-computed by the agent at generation time to spare a render-time formatter on every page).
       // ---------------------------------------------------------------------
       amountRaised: z.number().int().nonnegative(),
       amountRaisedFormatted: z.string(),


### PR DESCRIPTION
## Summary

- **Test count**: README updated from 57 → 65 to match the current vitest suite (grew with recent additions)
- **Cron paused**: Architecture diagram and repo layout in README now flag that `detect.yml`'s schedule is paused (since 2026-06-09, per Tyler); workflow_dispatch still active for one-off runs
- **Stale Wix references removed**: Three references to "Wix CMS" and "Wix rich-text field" in `prompts/case-study-prompt.md` replaced with accurate Astro content collection references; one "Wix-era workaround" comment in `src/content/config.ts` cleaned up
- **Prompt spec version**: Header updated from v3.3 → v4.0 to match `package.json`

## What was reviewed

The full repo was audited against its documentation. These were the only gaps found between the code and the docs — all other README sections (rate limits, cost model, known gaps, repo layout, stack) are accurate.

## Test plan

- [ ] `npm test` — 65 tests pass (no logic changes, only documentation)
- [ ] `npm run typecheck` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBsPonZKjBXnY8kUimyLC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBsPonZKjBXnY8kUimyLC5)_